### PR TITLE
gui: Add new 'custom' quality preset for placebo

### DIFF
--- a/gui/include/qmlmainwindow.h
+++ b/gui/include/qmlmainwindow.h
@@ -6,6 +6,7 @@
 #include <QWindow>
 #include <QQuickWindow>
 #include <QLoggingCategory>
+#include <QFileSystemWatcher>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -55,7 +56,8 @@ public:
     enum class VideoPreset {
         Fast,
         Default,
-        HighQuality
+        HighQuality,
+        Custom
     };
     Q_ENUM(VideoPreset);
 
@@ -154,6 +156,9 @@ private:
     bool quick_frame = false;
     bool quick_need_sync = false;
     std::atomic<bool> quick_need_render = {false};
+    QFileSystemWatcher *renderparams_watcher = {};
+    pl_options renderparams_opts = {};
+    bool renderparams_changed = false;
 
     struct {
         PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr;

--- a/gui/include/settings.h
+++ b/gui/include/settings.h
@@ -45,7 +45,8 @@ enum class Decoder
 enum class PlaceboPreset {
 	Fast,
 	Default,
-	HighQuality
+	HighQuality,
+	Custom
 };
 
 enum class WindowType {

--- a/gui/src/qml/SettingsDialog.qml
+++ b/gui/src/qml/SettingsDialog.qml
@@ -283,7 +283,7 @@ DialogView {
 
                     C.ComboBox {
                         Layout.preferredWidth: 400
-                        model: [qsTr("Fast"), qsTr("Default"), qsTr("High Quality")]
+                        model: [qsTr("Fast"), qsTr("Default"), qsTr("High Quality"), qsTr("Custom")]
                         currentIndex: Chiaki.settings.videoPreset
                         onActivated: (index) => {
                             Chiaki.settings.videoPreset = index;
@@ -291,6 +291,7 @@ DialogView {
                             case 0: Chiaki.window.videoPreset = ChiakiWindow.VideoPreset.Fast; break;
                             case 1: Chiaki.window.videoPreset = ChiakiWindow.VideoPreset.Default; break;
                             case 2: Chiaki.window.videoPreset = ChiakiWindow.VideoPreset.HighQuality; break;
+                            case 3: Chiaki.window.videoPreset = ChiakiWindow.VideoPreset.Custom; break;
                             }
                         }
                     }

--- a/gui/src/settings.cpp
+++ b/gui/src/settings.cpp
@@ -403,7 +403,8 @@ void Settings::SetDecoder(Decoder decoder)
 static const QMap<PlaceboPreset, QString> placebo_preset_values = {
 	{ PlaceboPreset::Fast, "fast" },
 	{ PlaceboPreset::Default, "default" },
-	{ PlaceboPreset::HighQuality, "high_quality" }
+	{ PlaceboPreset::HighQuality, "high_quality" },
+	{ PlaceboPreset::Custom, "custom" }
 };
 
 PlaceboPreset Settings::GetPlaceboPreset() const


### PR DESCRIPTION
Will monitor the file `pl_render_params.conf` in the Chiaki config directory (~/Library/Preferences for MacOS see https://doc.qt.io/qt-6/qstandardpaths.html for other platforms) for custom rendering settings and apply them to the running stream. For available options see [1], the syntax is simply a set of `key=value` pairs, separated from each other with either whitespace, comma, semicolon, colon or newline characters.

[1] https://libplacebo.org/options/