### PR TITLE
Replace FlyCI runners with GitHub runners

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -53,7 +53,7 @@ jobs:
 
   build-mac_arm64:
     name: Build macOSX arm64 version
-    runs-on: flyci-macos-large-latest-m2
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This PR replaces the use of FlyCI macOS runners with GitHub ones since FlyCI macOS runners will be discontinued effective Sep 30, 2024. 

[Read more about the discontinuation of the FlyCI macOS runners](https://flyci.net/blog/flyci-discontinue-macos-runners?utm_source=site_link&utm_medium=github&utm_campaign=discontinue-runners).