### PR TITLE
ui: added borealis view and associated callbacks for chiaki_event_login_pin_request

### DIFF
--- a/lib/src/session.c
+++ b/lib/src/session.c
@@ -183,7 +183,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_session_init(ChiakiSession *session, Chiaki
 	ChiakiErrorCode err = chiaki_cond_init(&session->state_cond);
 	if(err != CHIAKI_ERR_SUCCESS)
 		goto error;
-
+		
 	err = chiaki_mutex_init(&session->state_mutex, false);
 	if(err != CHIAKI_ERR_SUCCESS)
 		goto error_state_cond;
@@ -337,8 +337,9 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_session_set_controller_state(ChiakiSession 
 CHIAKI_EXPORT ChiakiErrorCode chiaki_session_set_login_pin(ChiakiSession *session, const uint8_t *pin, size_t pin_size)
 {
 	uint8_t *buf = malloc(pin_size);
-	if(!buf)
+	if(!buf){
 		return CHIAKI_ERR_MEMORY;
+	}
 	memcpy(buf, pin, pin_size);
 	ChiakiErrorCode err = chiaki_mutex_lock(&session->state_mutex);
 	assert(err == CHIAKI_ERR_SUCCESS);
@@ -523,7 +524,6 @@ static void *session_thread_func(void *arg)
 		event.login_pin_request.pin_incorrect = pin_incorrect;
 		chiaki_session_send_event(session, &event);
 		pin_incorrect = true;
-
 		err = chiaki_cond_timedwait_pred(&session->state_cond, &session->state_mutex, UINT64_MAX, session_check_state_pred_pin, session);
 		CHECK_STOP(quit_ctrl);
 		if(session->ctrl_failed)
@@ -539,7 +539,6 @@ static void *session_thread_func(void *arg)
 		free(session->login_pin);
 		session->login_pin = NULL;
 		session->login_pin_size = 0;
-
 		// wait for session id or new login pin request
 		err = chiaki_cond_timedwait_pred(&session->state_cond, &session->state_mutex, SESSION_EXPECT_TIMEOUT_MS, session_check_state_pred_ctrl_start, session);
 		CHECK_STOP(quit_ctrl);

--- a/switch/include/gui.h
+++ b/switch/include/gui.h
@@ -25,6 +25,7 @@ class HostInterface : public brls::List
 		IO *io;
 		Host *host;
 		Settings *settings;
+		ChiakiLog *log = nullptr;
 		bool connected = false;
 
 	public:
@@ -38,6 +39,7 @@ class HostInterface : public brls::List
 		void ConnectSession();
 		void Disconnect();
 		void Stream();
+		void EnterPin(bool isError);
 		void CloseStream(ChiakiQuitEvent *quit);
 };
 
@@ -76,4 +78,20 @@ class PSRemotePlay : public brls::View
 		void draw(NVGcontext *vg, int x, int y, unsigned width, unsigned height, brls::Style *style, brls::FrameContext *ctx) override;
 };
 
+
+
+class EnterPinView :public brls::View
+{
+	private:
+		Host *host;
+		std::string login_pin;
+		Settings *settings;
+		ChiakiLog *log = nullptr;
+		bool isError = false;
+	public:
+		EnterPinView(Host *host, bool isError);
+		~EnterPinView();
+		void ClosePinView();
+		void draw(NVGcontext *vg, int x, int y, unsigned width, unsigned height, brls::Style *style, brls::FrameContext *ctx) override;
+};
 #endif // CHIAKI_GUI_H

--- a/switch/include/host.h
+++ b/switch/include/host.h
@@ -90,6 +90,9 @@ class Host
 		ChiakiConnectVideoProfile video_profile;
 		friend class Settings;
 		friend class DiscoveryManager;
+		// allows session to be passed to gui
+		friend class HostInterface;
+		friend class EnterPinView;
 
 	public:
 		Host(std::string host_name);

--- a/switch/src/gui.cpp
+++ b/switch/src/gui.cpp
@@ -587,7 +587,8 @@ EnterPinView::~EnterPinView()
 
 void EnterPinView::ClosePinView()
 {
-	brls::Application::popView();	
+	brls::Application::popView();
+	brls::Application::unblockInputs();
 }
 
 void EnterPinView::draw(NVGcontext *vg, int x, int y, unsigned width, unsigned height, brls::Style *style, brls::FrameContext *ctx)


### PR DESCRIPTION
Initial PR. Will seat down and do some more testing over the week to see how it plays with other scenarios.

However, the basic flow:
- Initiate a connection request
- Receive connection pin request from ctrl
- Deliberately submit a wrong pin
- Receive an incorrect pin notification from ctrl
- Submit correct pin
- Session begins
works.

![image](https://github.com/user-attachments/assets/c982c7e0-4d9d-4cd4-b1f8-7e5e3362870a)
![image](https://github.com/user-attachments/assets/d8d0ff91-4920-4d24-a0d1-1673f90ade2b)

Upon the right pin being submitted, EnterPinView is popped and PSRemotePlay continues to initiate the stream session.