### PR TITLE
Suppress Apple warning for unsigned app & update docs

### DIFF
--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -39,6 +39,17 @@
         ```
         brew install --cask streetpea/streetpea/chiaki-ng
         ```
+    
+    > [!NOTE]
+    > By using chiaki-ng, you acknowledge that it's not [notarized](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution).
+    >
+    > Notarization is a "security" feature by Apple.
+    > You send binaries to Apple, and they either approve them or not.
+    > In reality, notarization is about building binaries the way Apple likes it.
+    >
+    > [Homebrew installation script](https://github.com/nikitabobko/homebrew-tap/blob/main/scripts/chiaki-ng.rb) is configured to
+    > automatically delete `com.apple.quarantine` attribute, that's why the app should work out of the box, without any warnings that
+    > "Apple cannot check chiaki-ng for malicious software"
 
 === "MacOS/Windows/Linux Appimage Package"
 

--- a/scripts/chiaki-ng.rb
+++ b/scripts/chiaki-ng.rb
@@ -15,6 +15,10 @@ cask "chiaki-ng" do
     url "https://github.com/streetpea/chiaki-ng/releases"
   end
 
+  postflight do
+    system "xattr -d com.apple.quarantine #{appdir}/chiaki-ng.app"
+  end
+
   app "chiaki-ng.app"
 
   zap trash: [


### PR DESCRIPTION
Recently saw this error when installing via Homebrew on macOS:
![image](https://github.com/user-attachments/assets/fedb422b-cb2d-4a77-83ec-58999d4af619)

Stumbled across [another repo](https://github.com/nikitabobko/AeroSpace?tab=readme-ov-file#installation) that seems to have a way to suppress that warning. I've attempted to do the same here, but I'm not at all familiar with homebrew packages, so I can't guarantee I've done it right for this repo.

I've also attempted to update the documentation with a note about the warning message suppression. Maintainers will probably want to ensure it's using the language the want.