### PR TITLE
Display correct icon when running under Flatpak on Wayland

### DIFF
--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -96,7 +96,7 @@ int real_main(int argc, char *argv[])
 		return 1;
 	}
 
-    	SDL_SetHint(SDL_HINT_APP_NAME, "chiaki-ng");
+	SDL_SetHint(SDL_HINT_APP_NAME, "chiaki-ng");
 
 	if(SDL_Init(SDL_INIT_AUDIO) < 0)
 	{

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -67,10 +67,13 @@ int real_main(int argc, char *argv[])
 	QGuiApplication::setApplicationName("Chiaki");
 	QGuiApplication::setApplicationVersion(CHIAKI_VERSION);
 	QGuiApplication::setApplicationDisplayName("chiaki-ng");
-	QGuiApplication::setDesktopFileName("chiaki-ng");
 
 	// TODO: When upgrading to SDL3, this also needs to be set on "SDL_HINT_APP_ID"
-	QApplication::setDesktopFileName("io.github.streetpea.Chiaki4deck");
+	if (QFile::exists("/.flatpak-info")) {
+		QApplication::setDesktopFileName("io.github.streetpea.Chiaki4deck");
+	} else {
+		QApplication::setDesktopFileName("chiaki-ng");
+	}
 
 	qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu");
 #if defined(Q_OS_WIN)

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -69,6 +69,9 @@ int real_main(int argc, char *argv[])
 	QGuiApplication::setApplicationDisplayName("chiaki-ng");
 	QGuiApplication::setDesktopFileName("chiaki-ng");
 
+	// TODO: When upgrading to SDL3, this also needs to be set on "SDL_HINT_APP_ID"
+	QApplication::setDesktopFileName("io.github.streetpea.Chiaki4deck");
+
 	qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu");
 #if defined(Q_OS_WIN)
 	const size_t cSize = strlen(argv[0])+1;
@@ -93,7 +96,7 @@ int real_main(int argc, char *argv[])
 		return 1;
 	}
 
-    SDL_SetHint(SDL_HINT_APP_NAME, "chiaki-ng");
+    	SDL_SetHint(SDL_HINT_APP_NAME, "chiaki-ng");
 
 	if(SDL_Init(SDL_INIT_AUDIO) < 0)
 	{


### PR DESCRIPTION
There's no truly definitive way of determining you're in a Flatpak, but checking for the existence of `/.flatpak-info` seems to work well.

