### PR TITLE
Add option to change ip address direct from switch interface

### DIFF
--- a/switch/include/settings.h
+++ b/switch/include/settings.h
@@ -126,6 +126,8 @@ class Settings
 
 		int GetHostRPKeyType(Host * host);
 		bool SetHostRPKeyType(Host * host, std::string value);
+
+		void SetHostAddr(Host* host, const std::string& addr);
 };
 
 #endif // CHIAKI_SETTINGS_H

--- a/switch/include/settings.h
+++ b/switch/include/settings.h
@@ -95,6 +95,7 @@ class Settings
 
 		std::string GetHostName(Host * host);
 		std::string GetHostAddr(Host * host);
+		void SetHostAddr(Host * host, std::string host_addr);
 
 		std::string GetPSNOnlineID(Host * host);
 		void SetPSNOnlineID(Host * host, std::string psn_online_id);
@@ -126,8 +127,6 @@ class Settings
 
 		int GetHostRPKeyType(Host * host);
 		bool SetHostRPKeyType(Host * host, std::string value);
-
-		void SetHostAddr(Host* host, const std::string& addr);
 };
 
 #endif // CHIAKI_SETTINGS_H

--- a/switch/src/gui.cpp
+++ b/switch/src/gui.cpp
@@ -511,46 +511,39 @@ bool MainApplication::BuildConfigurationMenu(brls::List *ls, Host *host)
 	ls->addView(haptic);
 
 	if(host != nullptr)
-	{
-	    // message delimiter
+	{	
 	    brls::Label *info = new brls::Label(brls::LabelStyle::REGULAR,
 		"Host information", true);
 	    ls->addView(info);
 	
-	    // Declaração única das variáveis
 	    std::string host_name_string = this->settings->GetHostName(host);
 	    brls::ListItem *host_name = new brls::ListItem("PS Hostname");
 	    host_name->setValue(host_name_string.c_str());
 	    ls->addView(host_name);
 	
-	    std::string host_addr_string = settings->GetHostAddr(host);
-	    brls::InputListItem *host_addr = new brls::InputListItem(
-		"PS Address", 
-		host_addr_string, 
-		"IP address or hostname", 
-		"", // Descrição (opcional)
-		255, // Tamanho máximo do campo
-		brls::KeyboardKeyDisableBitmask::KEYBOARD_DISABLE_NONE // Permite todos os caracteres
-	    );
-	
-	    // Captura host_addr por referência na lambda
-	    auto host_addr_cb = [this, host, host_addr](brls::View *view) {
-		std::string new_addr = host_addr->getValue();
-	
-		// Validação básica do endereço (opcional)
-		if (new_addr.empty()) {
-		    brls::Application::notify("PS Address cannot be empty");
-		    return;
-		}
-	
-		this->settings->SetHostAddr(host, new_addr);	
-		this->settings->WriteFile();	
-	
-		brls::Application::notify("PS Address updated successfully");
+	    std::string host_addr_string = settings->GetHostAddr(host);		
+		brls::InputListItem *host_addr = new brls::InputListItem("Remote IP/name",
+		host_addr_string, "IP address or fqdn", "", 255,
+		brls::KeyboardKeyDisableBitmask::KEYBOARD_DISABLE_SPACE |
+			brls::KeyboardKeyDisableBitmask::KEYBOARD_DISABLE_AT |
+			brls::KeyboardKeyDisableBitmask::KEYBOARD_DISABLE_PERCENT |
+			brls::KeyboardKeyDisableBitmask::KEYBOARD_DISABLE_FORWSLASH |
+			brls::KeyboardKeyDisableBitmask::KEYBOARD_DISABLE_BACKSLASH);		
+		
+	    auto host_addr_cb = [this, host, host_addr](brls::View *view)
+		{
+			std::string new_addr = host_addr->getValue();	
+			this->settings->SetHostAddr(host, new_addr);	
+			this->settings->WriteFile();		
+			brls::Application::notify("PS Address updated successfully");
 	    };
 	
 	    host_addr->getClickEvent()->subscribe(host_addr_cb);
 	    ls->addView(host_addr);
+
+		brls::ListItem *host_regist_state_item = new brls::ListItem("Register Status");
+		host_regist_state_item->setValue(!settings->GetHostRPKey(host).empty() ? "registered" : "unregistered");
+		ls->addView(host_regist_state_item);
 	}
 
 	return true;

--- a/switch/src/gui.cpp
+++ b/switch/src/gui.cpp
@@ -522,11 +522,29 @@ bool MainApplication::BuildConfigurationMenu(brls::List *ls, Host *host)
 		host_name->setValue(host_name_string.c_str());
 		ls->addView(host_name);
 
-		std::string host_addr_string = settings->GetHostAddr(host);
-		brls::ListItem *host_addr = new brls::ListItem("PS Address");
-		host_addr->setValue(host_addr_string.c_str());
+		std::string host_name_string = this->settings->GetHostName(host);
+	    	brls::ListItem *host_name = new brls::ListItem("PS Hostname");
+	   	host_name->setValue(host_name_string.c_str());
+	   	ls->addView(host_name);
+	
+	  	std::string host_addr_string = settings->GetHostAddr(host);
+		brls::InputListItem *host_addr = new brls::InputListItem(
+			"PS Address", 
+			host_addr_string, 
+			"IP address or hostname",
+			brls::KeyboardKeyDisableBitmask::KEYBOARD_DISABLE_NONE // Permite todos os caracteres
+		    );
+		
+		// Captura host_addr por referência na lambda
+		auto host_addr_cb = [this, host, host_addr](brls::View *view) {
+			std::string new_addr = host_addr->getValue();
+			this->settings->SetHostAddr(host, new_addr); // Atualiza o endereço no settings
+			this->settings->WriteFile(); // Salva no arquivo de configuração
+		};
+		
+		host_addr->getClickEvent()->subscribe(host_addr_cb);
 		ls->addView(host_addr);
-
+		
 		brls::ListItem *host_regist_state_item = new brls::ListItem("Register Status");
 		host_regist_state_item->setValue(!settings->GetHostRPKey(host).empty() ? "registered" : "unregistered");
 		ls->addView(host_regist_state_item);

--- a/switch/src/gui.cpp
+++ b/switch/src/gui.cpp
@@ -512,42 +512,45 @@ bool MainApplication::BuildConfigurationMenu(brls::List *ls, Host *host)
 
 	if(host != nullptr)
 	{
-		// message delimiter
-		brls::Label *info = new brls::Label(brls::LabelStyle::REGULAR,
-			"Host information", true);
-		ls->addView(info);
-
-		std::string host_name_string = this->settings->GetHostName(host);
-		brls::ListItem *host_name = new brls::ListItem("PS Hostname");
-		host_name->setValue(host_name_string.c_str());
-		ls->addView(host_name);
-
-		std::string host_name_string = this->settings->GetHostName(host);
-	    	brls::ListItem *host_name = new brls::ListItem("PS Hostname");
-	   	host_name->setValue(host_name_string.c_str());
-	   	ls->addView(host_name);
+	    // message delimiter
+	    brls::Label *info = new brls::Label(brls::LabelStyle::REGULAR,
+		"Host information", true);
+	    ls->addView(info);
 	
-	  	std::string host_addr_string = settings->GetHostAddr(host);
-		brls::InputListItem *host_addr = new brls::InputListItem(
-			"PS Address", 
-			host_addr_string, 
-			"IP address or hostname",
-			brls::KeyboardKeyDisableBitmask::KEYBOARD_DISABLE_NONE // Permite todos os caracteres
-		    );
-		
-		// Captura host_addr por referência na lambda
-		auto host_addr_cb = [this, host, host_addr](brls::View *view) {
-			std::string new_addr = host_addr->getValue();
-			this->settings->SetHostAddr(host, new_addr); // Atualiza o endereço no settings
-			this->settings->WriteFile(); // Salva no arquivo de configuração
-		};
-		
-		host_addr->getClickEvent()->subscribe(host_addr_cb);
-		ls->addView(host_addr);
-		
-		brls::ListItem *host_regist_state_item = new brls::ListItem("Register Status");
-		host_regist_state_item->setValue(!settings->GetHostRPKey(host).empty() ? "registered" : "unregistered");
-		ls->addView(host_regist_state_item);
+	    // Declaração única das variáveis
+	    std::string host_name_string = this->settings->GetHostName(host);
+	    brls::ListItem *host_name = new brls::ListItem("PS Hostname");
+	    host_name->setValue(host_name_string.c_str());
+	    ls->addView(host_name);
+	
+	    std::string host_addr_string = settings->GetHostAddr(host);
+	    brls::InputListItem *host_addr = new brls::InputListItem(
+		"PS Address", 
+		host_addr_string, 
+		"IP address or hostname", 
+		"", // Descrição (opcional)
+		255, // Tamanho máximo do campo
+		brls::KeyboardKeyDisableBitmask::KEYBOARD_DISABLE_NONE // Permite todos os caracteres
+	    );
+	
+	    // Captura host_addr por referência na lambda
+	    auto host_addr_cb = [this, host, host_addr](brls::View *view) {
+		std::string new_addr = host_addr->getValue();
+	
+		// Validação básica do endereço (opcional)
+		if (new_addr.empty()) {
+		    brls::Application::notify("PS Address cannot be empty");
+		    return;
+		}
+	
+		this->settings->SetHostAddr(host, new_addr);	
+		this->settings->WriteFile();	
+	
+		brls::Application::notify("PS Address updated successfully");
+	    };
+	
+	    host_addr->getClickEvent()->subscribe(host_addr_cb);
+	    ls->addView(host_addr);
 	}
 
 	return true;

--- a/switch/src/settings.cpp
+++ b/switch/src/settings.cpp
@@ -635,4 +635,17 @@ void Settings::SetCPUOverclock(Host *host, std::string value)
 	int v = atoi(value.c_str());
 	this->SetCPUOverclock(host, v);
 }
+
+void Settings::SetHostAddr(Host *host, const std::string& addr)
+{
+    if (host == nullptr)
+    {
+        CHIAKI_LOGE(&this->log, "Cannot SetHostAddr on nullptr host");
+        return;
+    }
+	
+    host->host_addr = addr;
+    this->WriteFile();
+}
+
 #endif

--- a/switch/src/settings.cpp
+++ b/switch/src/settings.cpp
@@ -362,6 +362,17 @@ std::string Settings::GetHostAddr(Host *host)
 	return "";
 }
 
+void Settings::SetHostAddr(Host * host, std::string host_addr)
+{
+    if (host == nullptr)
+    {
+        CHIAKI_LOGE(&this->log, "Cannot SetHostAddr on nullptr host");
+        return;
+    }
+	
+    host->host_addr = host_addr;
+}
+
 std::string Settings::GetPSNOnlineID(Host *host)
 {
 	if(host == nullptr || host->psn_online_id.length() == 0)
@@ -635,17 +646,4 @@ void Settings::SetCPUOverclock(Host *host, std::string value)
 	int v = atoi(value.c_str());
 	this->SetCPUOverclock(host, v);
 }
-
-void Settings::SetHostAddr(Host *host, const std::string& addr)
-{
-    if (host == nullptr)
-    {
-        CHIAKI_LOGE(&this->log, "Cannot SetHostAddr on nullptr host");
-        return;
-    }
-	
-    host->host_addr = addr;
-    this->WriteFile();
-}
-
 #endif


### PR DESCRIPTION
For the people with dynamic ip, and use chikai over the internet, you can now change it direct in the interface to enter the new ip, without the need to change the .conf file manually or create a new setup with the new ip, just change the alrady registered profile with the new ip and you are done with it till the ISP change your IP again.