### PR TITLE
Readme logo dependant on GitHub theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 ![chiaki-ng Logo](gui/res/chiaking-logo-white.svg#gh-dark-mode-only)
-![chiaki-ng Logo](gui/res/chiaking-logo.svg#gh-light)
+![chiaki-ng Logo](gui/res/chiaking-logo.svg#gh-light-mode-only)
 
 # [chiaki-ng](https://streetpea.github.io/chiaki-ng/)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
-![chiaki-ng Logo](gui/res/chiaking-logo.svg)
+![chiaki-ng Logo](gui/res/chiaking-logo-white.svg#gh-dark-mode-only)
+![chiaki-ng Logo](gui/res/chiaking-logo.svg#gh-light)
 
 # [chiaki-ng](https://streetpea.github.io/chiaki-ng/)
 


### PR DESCRIPTION
When the user is using Light mode they will see the normal logo, but when the user is using dark mode they will see the chiaking-logo-white, because the colored logo is dark and hardly visible on github's dark background 