### PR TITLE
Updated podman --volume option for Fedora compatability.

### DIFF
--- a/scripts/run-podman-build-appimage.sh
+++ b/scripts/run-podman-build-appimage.sh
@@ -6,7 +6,7 @@ cd "`dirname $(readlink -f ${0})`"
 podman build -t chiaki-qt6 . -f Dockerfile.qt6
 cd ..
 podman run --rm \
-	-v "`pwd`:/build/chiaki" \
+	--volume "`pwd`:/build/chiaki:Z" \
 	-w "/build/chiaki" \
 	--device /dev/fuse \
 	--cap-add SYS_ADMIN \


### PR DESCRIPTION
The default run-podman-build-appimage script does not work in Fedora as the chiaki build directory does not mount in the container with proper permissions. I am unsure of the root cause though if things were tested on Ubuntu it is possible there are crun vs. runc differences.

This patch fixes the bug by expanding `-v` to `--volume` (to avoid potential cli aliasing problems) and adds the Z option to map selinux contexts appropriately.