### PR TITLE
settings.h: Update Host Address Regex to support FQDN

### DIFF
--- a/switch/include/settings.h
+++ b/switch/include/settings.h
@@ -57,7 +57,7 @@ class Settings
 		// the goal is to read/write inernal flat configuration file
 		const std::map<Settings::ConfigurationItem, std::regex> re_map = {
 			{HOST_NAME, std::regex("^\\[\\s*(.+)\\s*\\]")},
-			{HOST_ADDR, std::regex("^\\s*host_(?:ip|addr)\\s*=\\s*\"?((\\d+\\.\\d+\\.\\d+\\.\\d+)|([A-Za-z0-9-]{1,255}))\"?")},
+			{HOST_ADDR, std::regex("^\\s*host_(?:ip|addr)\\s*=\\s*\"?((\\d+\\.\\d+\\.\\d+\\.\\d+)|([A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)+))\"?")},
 			{PSN_ONLINE_ID, std::regex("^\\s*psn_online_id\\s*=\\s*\"?([\\w_-]+)\"?")},
 			{PSN_ACCOUNT_ID, std::regex("^\\s*psn_account_id\\s*=\\s*\"?([\\w/=+]+)\"?")},
 			{RP_KEY, std::regex("^\\s*rp_key\\s*=\\s*\"?([\\w/=+]+)\"?")},


### PR DESCRIPTION
Should fix the config issue with hostnames and stopping at the first word in the domain.