### PR TITLE
feat (session, streamconnection): add optional ability to session to immediately request IDR when a corupted frame is received.

### DIFF
--- a/lib/include/chiaki/session.h
+++ b/lib/include/chiaki/session.h
@@ -88,6 +88,7 @@ typedef struct chiaki_connect_info_t
 	chiaki_socket_t *rudp_sock;
 	uint8_t psn_account_id[CHIAKI_PSN_ACCOUNT_ID_SIZE];
 	double packet_loss_max;
+	bool enable_idr_on_fec_failure;
 } ChiakiConnectInfo;
 
 
@@ -217,6 +218,7 @@ typedef struct chiaki_session_t
 		bool enable_keyboard;
 		bool enable_dualsense;
 		uint8_t psn_account_id[CHIAKI_PSN_ACCOUNT_ID_SIZE];
+		bool enable_idr_on_fec_failure;
 	} connect_info;
 
 	ChiakiTarget target;

--- a/lib/include/chiaki/streamconnection.h
+++ b/lib/include/chiaki/streamconnection.h
@@ -95,6 +95,7 @@ CHIAKI_EXPORT ChiakiErrorCode stream_connection_send_toggle_mute_direct_message(
 CHIAKI_EXPORT ChiakiErrorCode chiaki_stream_connection_stop(ChiakiStreamConnection *stream_connection);
 
 CHIAKI_EXPORT ChiakiErrorCode stream_connection_send_corrupt_frame(ChiakiStreamConnection *stream_connection, ChiakiSeqNum16 start, ChiakiSeqNum16 end);
+CHIAKI_EXPORT ChiakiErrorCode stream_connection_send_idr_request(ChiakiStreamConnection *stream_connection);
 
 #ifdef __cplusplus
 }

--- a/lib/include/chiaki/videoreceiver.h
+++ b/lib/include/chiaki/videoreceiver.h
@@ -33,6 +33,7 @@ typedef struct chiaki_video_receiver_t
 	int32_t frames_lost;
 	int32_t reference_frames[16];
 	ChiakiBitstream bitstream;
+	bool waiting_for_idr;
 } ChiakiVideoReceiver;
 
 CHIAKI_EXPORT void chiaki_video_receiver_init(ChiakiVideoReceiver *video_receiver, struct chiaki_session_t *session, ChiakiPacketStats *packet_stats);

--- a/lib/src/session.c
+++ b/lib/src/session.c
@@ -263,6 +263,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_session_init(ChiakiSession *session, Chiaki
 	session->connect_info.video_profile_auto_downgrade = connect_info->video_profile_auto_downgrade;
 	session->connect_info.enable_keyboard = connect_info->enable_keyboard;
 	session->connect_info.enable_dualsense = connect_info->enable_dualsense;
+	session->connect_info.enable_idr_on_fec_failure = connect_info->enable_idr_on_fec_failure;
 
 	return CHIAKI_ERR_SUCCESS;
 

--- a/lib/src/streamconnection.c
+++ b/lib/src/streamconnection.c
@@ -1280,3 +1280,22 @@ CHIAKI_EXPORT ChiakiErrorCode stream_connection_send_corrupt_frame(ChiakiStreamC
 	CHIAKI_LOGD(stream_connection->log, "StreamConnection reporting corrupt frame(s) from %u to %u", (unsigned int)start, (unsigned int)end);
 	return chiaki_takion_send_message_data(&stream_connection->takion, 1, 2, buf, stream.bytes_written, NULL);
 }
+
+CHIAKI_EXPORT ChiakiErrorCode stream_connection_send_idr_request(ChiakiStreamConnection *stream_connection)
+{
+	tkproto_TakionMessage msg = { 0 };
+	msg.type = tkproto_TakionMessage_PayloadType_IDRREQUEST;
+
+	uint8_t buf[0x10];
+
+	pb_ostream_t stream = pb_ostream_from_buffer(buf, sizeof(buf));
+	bool pbr = pb_encode(&stream, tkproto_TakionMessage_fields, &msg);
+	if(!pbr)
+	{
+		CHIAKI_LOGE(stream_connection->log, "StreamConnection IDR request protobuf encoding failed");
+		return CHIAKI_ERR_UNKNOWN;
+	}
+
+	CHIAKI_LOGI(stream_connection->log, "StreamConnection requesting IDR frame");
+	return chiaki_takion_send_message_data(&stream_connection->takion, 1, 2, buf, stream.bytes_written, NULL);
+}


### PR DESCRIPTION
On NX, there are only 4 cores avaliable, but most of the work takes place on the fourth core

I have been deliberately sabotaging my own Wi-Fi setup by using 2.4ghz to try and reproduce some reported crashes and I can see this occur with fairly common occurrence now:


```
21:03:48.824[0;34m[INFO][0m Ctrl received Heartbeat, sending reply
21:03:49.043[0;34m[INFO][0m connectionEventCallback: event type=10
21:03:49.290[0;34m[INFO][0m draw #301, init=true, tex=true, buf=true
21:03:49.307[0;34m[INFO][0m renderStatsOverlay #301: show=false, text_init=true, font_id=6
21:03:49.329[0;34m[INFO][0m connectionEventCallback: event type=10
21:03:49.357[0;34m[INFO][0m updateTextureBindings #301, addr=0xb79c15000
21:03:49.557[0;34m[INFO][0m StreamView::draw #361: streamActive=true, sessionStarted=true, menuOpen=false
21:03:49.845[0;34m[INFO][0m Frame Processor received 20+0 / 30+1 units, attempting FEC
21:03:49.845[0;33m[WARNING][0m Increasing received packets to reduce hit on stream quality
21:03:49.845[0;31m[ERROR][0m FEC failed
21:03:49.845[0;33m[WARNING][0m Missing unit 0x11
21:03:49.846[0;33m[WARNING][0m Missing unit 0x12
21:03:49.846[0;33m[WARNING][0m Missing unit 0x13
21:03:49.846[0;33m[WARNING][0m Missing unit 0x14
21:03:49.846[0;33m[WARNING][0m Missing unit 0x15
21:03:49.846[0;33m[WARNING][0m Missing unit 0x16
21:03:49.846[0;33m[WARNING][0m Missing unit 0x17
21:03:49.846[0;33m[WARNING][0m Missing unit 0x18
21:03:49.846[0;33m[WARNING][0m Missing unit 0x1c
21:03:49.846[0;33m[WARNING][0m Missing unit 0x1d
21:03:49.847[0;33m[WARNING][0m Failed to complete frame 332
21:03:49.847[0;33m[WARNING][0m Video receiver could not flush frame.
21:03:49.847[0;33m[WARNING][0m Detected missing or corrupt frame(s) from 332 to 333
21:03:49.851[0;33m[WARNING][0m Missing reference frame 332 for decoding frame 333 -> changed to 331
[hevc @ 0xb7727aa20] Could not find ref with POC 331
[hevc @ 0xb7727aa20] Error constructing the frame RPS.
[hevc @ 0xb7727aa20] Skipping invalid undecodable NALU: 1
[hevc @ 0xb7727aa20] Could not find ref with POC 332
[hevc @ 0xb7727aa20] Error constructing the frame RPS.
[hevc @ 0xb7727aa20] Skipping invalid undecodable NALU: 1
[hevc @ 0xb7727aa20] Could not find ref with POC 333
[hevc @ 0xb7727aa20] Error constructing the frame RPS.
[hevc @ 0xb7727aa20] Skipping invalid undecodable NALU: 1
[hevc @ 0xb7727aa20] Could not find ref with POC 334
[hevc @ 0xb7727aa20] Error constructing the frame RPS.
[hevc @ 0xb7727aa20] Skipping invalid undecodable NALU: 1
[hevc @ 0xb7727aa20] Could not find ref with POC 335
[hevc @ 0xb7727aa20] Error constructing the frame RPS.
[hevc @ 0xb7727aa20] Skipping invalid undecodable NALU: 1
[hevc @ 0xb7727aa20] Could not find ref with POC 336
[hevc @ 0xb7727aa20] Error constructing the frame RPS.
[hevc @ 0xb7727aa20] Skipping invalid undecodable NALU: 1
[hevc @ 0xb7727aa20] Could not find ref with POC 337
[hevc @ 0xb7727aa20] Error constructing the frame RPS.
[hevc @ 0xb7727aa20] Skipping invalid undecodable NALU: 1
[hevc @ 0xb7727aa20] Could not find ref with POC 338
[hevc @ 0xb7727aa20] Error constructing the frame RPS.
[hevc @ 0xb7727aa20] Skipping invalid undecodable NALU: 1
[hevc @ 0xb7727aa20] Could not find ref with POC 339
[hevc @ 0xb7727aa20] Error constructing the frame RPS.
[hevc @ 0xb7727aa20] Skipping invalid undecodable NALU: 1
[hevc @ 0xb7727aa20] Could not find ref with POC 340
[hevc @ 0xb7727aa20] Error constructing the frame RPS.
[hevc @ 0xb7727aa20] Skipping invalid undecodable NALU: 1
[hevc @ 0xb7727aa20] Could not find ref with POC 341
[hevc @ 0xb7727aa20] Error constructing the frame RPS.
[hevc @ 0xb7727aa20] Skipping invalid undecodable NALU: 1
[hevc @ 0xb7727aa20] Could not find ref with POC 342
....
exited.
```

It looks to me like what happens is that as garbage P-frames are being sent when the IDR frame is corrupted, NX spends too much on processing the garbage packet, and trying to draw them. until either a) it is essentially resent and it somehow recovers or b) it just outright crashes out.

This adds an option in stream session (still in testing) to immediately request for an IDR frame the second a corrupted frame is received, and to stop sending garbage P-frames that cannot be decoded. this should not be the default, and should only be used in the event that the CPU is very weak. It will seem jerky, but it beats an outright crash / long hanging and now has approx 200 ms recovery.
```
20:22:20.386[INFO] StreamView::draw #28861: streamActive=true, sessionStarted=true, menuOpen=false
20:22:20.974[INFO] Frame Processor received 23+1 / 30+1 units, attempting FEC
20:22:20.975[ERROR] FEC failed
20:22:20.975[WARNING] Missing unit 0x2
20:22:20.975[WARNING] Missing unit 0x3
20:22:20.975[WARNING] Missing unit 0x4
20:22:20.975[WARNING] Missing unit 0x5
20:22:20.975[WARNING] Missing unit 0x7
20:22:20.976[WARNING] Missing unit 0x8
20:22:20.976[WARNING] Missing unit 0x9
20:22:20.976[INFO] StreamConnection requesting IDR frame
20:22:20.976[INFO] FEC failed, waiting for IDR frame
20:22:20.976[WARNING] Failed to complete frame 28590
20:22:20.976[WARNING] Video receiver could not flush frame.
20:22:20.976[WARNING] Detected missing or corrupt frame(s) from 28590 to 28591
20:22:20.985[WARNING] Detected missing or corrupt frame(s) from 28590 to 28592
20:22:20.991[WARNING] Detected missing or corrupt frame(s) from 28590 to 28593
20:22:21.001[WARNING] Detected missing or corrupt frame(s) from 28590 to 28594
20:22:21.014[WARNING] Detected missing or corrupt frame(s) from 28590 to 28595
20:22:21.030[WARNING] Detected missing or corrupt frame(s) from 28590 to 28596
20:22:21.047[WARNING] Detected missing or corrupt frame(s) from 28590 to 28597
20:22:21.064[WARNING] Detected missing or corrupt frame(s) from 28590 to 28598
20:22:21.080[WARNING] Detected missing or corrupt frame(s) from 28590 to 28599
20:22:21.109[WARNING] Increasing received packets to reduce hit on stream quality
20:22:21.122[INFO] Received IDR frame, resuming decode
```

This is what it should look like when called.

Still undergoing alpha testing in Akira with some other testers

