### PR TITLE
fix: add iOS/tvOS compilation support for Apple platforms

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -125,7 +125,7 @@ if(WIN32)
 	target_link_libraries(chiaki-lib wsock32 ws2_32 bcrypt iphlpapi)
 endif()
 
-if(APPLE)
+if(APPLE AND NOT IOS AND NOT TVOS)
 	target_link_libraries(chiaki-lib "-framework CoreServices")
 endif()
 

--- a/lib/src/gkcrypt.c
+++ b/lib/src/gkcrypt.c
@@ -387,7 +387,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_gkcrypt_gmac(ChiakiGKCrypt *gkcrypt, uint64
 	}
 
 	// encrypt without additional data
-	if(mbedtls_gcm_starts(&actx, MBEDTLS_GCM_ENCRYPT, iv, CHIAKI_GKCRYPT_BLOCK_SIZE) != 0)
+	if(mbedtls_gcm_starts(&actx, MBEDTLS_GCM_ENCRYPT, iv, CHIAKI_GKCRYPT_BLOCK_SIZE, NULL, 0) != 0)
 	{
 		mbedtls_gcm_free(&actx);
 		return CHIAKI_ERR_UNKNOWN;

--- a/lib/src/takion.c
+++ b/lib/src/takion.c
@@ -15,7 +15,10 @@
 #include <assert.h>
 
 #ifdef __APPLE__
+#include <TargetConditionals.h>
+#if TARGET_OS_OSX
 #include <CoreServices/CoreServices.h>
+#endif
 #endif
 
 #ifdef _WIN32
@@ -253,7 +256,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_takion_connect(ChiakiTakion *takion, Chiaki
 			goto error_sock;
 		}
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && TARGET_OS_OSX
 		SInt32 majorVersion;
 		Gestalt(gestaltSystemVersionMajor, &majorVersion);
 		if(majorVersion < 11)
@@ -342,7 +345,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_takion_connect(ChiakiTakion *takion, Chiaki
 		}
 		if(info->ip_dontfrag)
 		{
-#if defined(__APPLE__)
+#if defined(__APPLE__) && TARGET_OS_OSX
 			SInt32 majorVersion;
 			Gestalt(gestaltSystemVersionMajor, &majorVersion);
 			if(majorVersion < 11)


### PR DESCRIPTION
## Summary

- **takion.c**: Guard `CoreServices.h` include and `Gestalt()` calls with `TARGET_OS_OSX` — these APIs are macOS-only and cause compilation failures on iOS/tvOS
- **gkcrypt.c**: Add missing `NULL, 0` additional data parameters to `mbedtls_gcm_starts()` for mbedtls 2.17+ API compatibility (6-param signature). This also fixes any build using `CHIAKI_LIB_ENABLE_MBEDTLS` with the vendored v2.28.0
- **lib/CMakeLists.txt**: Conditionally link CoreServices framework only on macOS, skip for iOS/tvOS targets

## Context

Building libchiaki for iOS/tvOS fails due to:
1. `CoreServices/CoreServices.h` and `Gestalt()` are macOS-only APIs not available on iOS/tvOS
2. `mbedtls_gcm_starts()` in mbedtls v2.28.0 (the version pinned in CMakeLists.txt) requires 6 parameters, but the current code passes only 4
3. CoreServices framework linking is unconditional under `if(APPLE)`, but should be macOS-only

## Test plan

- [x] Verified compilation on macOS — `Gestalt` symbol present, no behavior change
- [x] Verified compilation on iOS arm64 / iOS Simulator (arm64+x86_64) / tvOS arm64
- [x] Verified `IP_DONTFRAG` socket option is defined and compiles on iOS/tvOS SDK
- [x] Verified mbedtls GCM encryption path — `_mbedtls_gcm_starts` and `_chiaki_gkcrypt_gmac` symbols correctly present in iOS/tvOS static libraries
- [x] Verified `Gestalt` symbol absent from iOS/tvOS slices (no macOS-only API leakage)

## Note

`Gestalt()` has been deprecated since macOS 10.8. A follow-up could replace it with `__builtin_available(macOS 11.0, *)` or `NSProcessInfo`, but that's outside the scope of this compatibility fix.