### PR TITLE
feat: allow optional affinity for threads

### DIFF
--- a/lib/include/chiaki/thread.h
+++ b/lib/include/chiaki/thread.h
@@ -20,6 +20,23 @@ extern "C" {
 
 typedef void *(*ChiakiThreadFunc)(void *);
 
+typedef enum {
+	CHIAKI_THREAD_NAME_CTRL,
+	CHIAKI_THREAD_NAME_CONGESTION,
+	CHIAKI_THREAD_NAME_DISCOVERY,
+	CHIAKI_THREAD_NAME_DISCOVERY_SVC,
+	CHIAKI_THREAD_NAME_TAKION,
+	CHIAKI_THREAD_NAME_TAKION_SEND,
+	CHIAKI_THREAD_NAME_RUDP_SEND,
+	CHIAKI_THREAD_NAME_HOLEPUNCH,
+	CHIAKI_THREAD_NAME_FEEDBACK,
+	CHIAKI_THREAD_NAME_SESSION,
+	CHIAKI_THREAD_NAME_REGIST,
+	CHIAKI_THREAD_NAME_GKCRYPT
+} ChiakiThreadName;
+
+typedef void (*ChiakiThreadAffinityFunc)(ChiakiThreadName name, void *user);
+
 typedef struct chiaki_thread_t
 {
 #ifdef _WIN32
@@ -36,6 +53,8 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_create(ChiakiThread *thread, ChiakiT
 CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_join(ChiakiThread *thread, void **retval);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_timedjoin(ChiakiThread *thread, void **retval, uint64_t timeout_ms);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_set_name(ChiakiThread *thread, const char *name);
+CHIAKI_EXPORT void chiaki_thread_set_affinity(ChiakiThreadName name);
+CHIAKI_EXPORT void chiaki_thread_set_affinity_cb(ChiakiThreadAffinityFunc func, void *user);
 
 
 typedef struct chiaki_mutex_t

--- a/lib/src/congestioncontrol.c
+++ b/lib/src/congestioncontrol.c
@@ -7,6 +7,7 @@
 static void *congestion_control_thread_func(void *user)
 {
 	ChiakiCongestionControl *control = user;
+	chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_CONGESTION);
 
 	ChiakiErrorCode err = chiaki_bool_pred_cond_lock(&control->stop_cond);
 	if(err != CHIAKI_ERR_SUCCESS)

--- a/lib/src/ctrl.c
+++ b/lib/src/ctrl.c
@@ -307,6 +307,7 @@ static void ctrl_failed(ChiakiCtrl *ctrl, ChiakiQuitReason reason)
 static void *ctrl_thread_func(void *user)
 {
 	ChiakiCtrl *ctrl = user;
+	chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_CTRL);
 
 	ChiakiErrorCode err = chiaki_mutex_lock(&ctrl->notif_mutex);
 	assert(err == CHIAKI_ERR_SUCCESS);

--- a/lib/src/discovery.c
+++ b/lib/src/discovery.c
@@ -325,6 +325,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_discovery_thread_stop(ChiakiDiscoveryThread
 static void *discovery_thread_func(void *user)
 {
 	ChiakiDiscoveryThread *thread = user;
+	chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_DISCOVERY);
 	ChiakiDiscovery *discovery = thread->discovery;
 
 	while(1)
@@ -378,6 +379,7 @@ static void *discovery_thread_func(void *user)
 static void *discovery_thread_func_oneshot(void *user)
 {
 	ChiakiDiscoveryThread *thread = user;
+	chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_DISCOVERY);
 	ChiakiDiscovery *discovery = thread->discovery;
 
 	while(1)

--- a/lib/src/discoveryservice.c
+++ b/lib/src/discoveryservice.c
@@ -134,6 +134,7 @@ CHIAKI_EXPORT void chiaki_discovery_service_fini(ChiakiDiscoveryService *service
 static void *discovery_service_thread_func(void *user)
 {
 	ChiakiDiscoveryService *service = user;
+	chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_DISCOVERY_SVC);
 
 	ChiakiErrorCode err = chiaki_bool_pred_cond_lock(&service->stop_cond);
 	if(err != CHIAKI_ERR_SUCCESS)

--- a/lib/src/feedbacksender.c
+++ b/lib/src/feedbacksender.c
@@ -244,6 +244,7 @@ static bool state_cond_check(void *user)
 static void *feedback_sender_thread_func(void *user)
 {
 	ChiakiFeedbackSender *feedback_sender = user;
+	chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_FEEDBACK);
 
 	ChiakiErrorCode err = chiaki_mutex_lock(&feedback_sender->state_mutex);
 	if(err != CHIAKI_ERR_SUCCESS)

--- a/lib/src/gkcrypt.c
+++ b/lib/src/gkcrypt.c
@@ -501,6 +501,7 @@ static ChiakiErrorCode gkcrypt_generate_next_chunk(ChiakiGKCrypt *gkcrypt)
 static void *gkcrypt_thread_func(void *user)
 {
 	ChiakiGKCrypt *gkcrypt = user;
+	chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_GKCRYPT);
 	CHIAKI_LOGV(gkcrypt->log, "GKCrypt %d thread starting", (int)gkcrypt->index);
 
 	ChiakiErrorCode err = chiaki_mutex_lock(&gkcrypt->key_buf_mutex);

--- a/lib/src/regist.c
+++ b/lib/src/regist.c
@@ -231,6 +231,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_regist_request_payload_format(ChiakiTarget 
 static void *regist_thread_func(void *user)
 {
 	ChiakiRegist *regist = user;
+	chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_REGIST);
 
 	bool canceled = false;
 	bool success = false;

--- a/lib/src/remote/holepunch.c
+++ b/lib/src/remote/holepunch.c
@@ -1962,6 +1962,7 @@ static void random_uuidv4(char* out)
 */
 static void* websocket_thread_func(void *user) {
     Session* session = (Session*) user;
+    chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_HOLEPUNCH);
 
     char ws_url[128] = {0};
     snprintf(ws_url, sizeof(ws_url), "wss://%s/np/pushNotification", session->ws_fqdn);

--- a/lib/src/remote/rudpsendbuffer.c
+++ b/lib/src/remote/rudpsendbuffer.c
@@ -256,6 +256,7 @@ static bool rudp_send_buffer_check_pred_no_packets(void *user)
 static void *rudp_send_buffer_thread_func(void *user)
 {
 	ChiakiRudpSendBuffer *send_buffer = user;
+	chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_RUDP_SEND);
 
 	ChiakiErrorCode err = chiaki_mutex_lock(&send_buffer->mutex);
 	if(err != CHIAKI_ERR_SUCCESS)

--- a/lib/src/session.c
+++ b/lib/src/session.c
@@ -425,6 +425,7 @@ static bool session_check_state_pred_regist(void *user)
 static void *session_thread_func(void *arg)
 {
 	ChiakiSession *session = (ChiakiSession *)arg;
+	chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_SESSION);
 
 	chiaki_mutex_lock(&session->state_mutex);
 

--- a/lib/src/takion.c
+++ b/lib/src/takion.c
@@ -915,6 +915,7 @@ static void takion_data_drop(uint64_t seq_num, void *elem_user, void *cb_user)
 static void *takion_thread_func(void *user)
 {
 	ChiakiTakion *takion = user;
+	chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_TAKION);
 
 	uint32_t seq_num_remote_initial;
 	if(takion_handshake(takion, &seq_num_remote_initial) != CHIAKI_ERR_SUCCESS)

--- a/lib/src/takionsendbuffer.c
+++ b/lib/src/takionsendbuffer.c
@@ -206,6 +206,7 @@ static bool takion_send_buffer_check_pred_no_packets(void *user)
 static void *takion_send_buffer_thread_func(void *user)
 {
 	ChiakiTakionSendBuffer *send_buffer = user;
+	chiaki_thread_set_affinity(CHIAKI_THREAD_NAME_TAKION_SEND);
 
 	ChiakiErrorCode err = chiaki_mutex_lock(&send_buffer->mutex);
 	if(err != CHIAKI_ERR_SUCCESS)

--- a/lib/src/thread.c
+++ b/lib/src/thread.c
@@ -97,6 +97,21 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_set_name(ChiakiThread *thread, const
 	return CHIAKI_ERR_SUCCESS;
 }
 
+static ChiakiThreadAffinityFunc g_affinity_cb = NULL;
+static void *g_affinity_cb_user = NULL;
+
+CHIAKI_EXPORT void chiaki_thread_set_affinity(ChiakiThreadName name)
+{
+	if(g_affinity_cb)
+		g_affinity_cb(name, g_affinity_cb_user);
+}
+
+CHIAKI_EXPORT void chiaki_thread_set_affinity_cb(ChiakiThreadAffinityFunc func, void *user)
+{
+	g_affinity_cb = func;
+	g_affinity_cb_user = user;
+}
+
 CHIAKI_EXPORT ChiakiErrorCode chiaki_mutex_init(ChiakiMutex *mutex, bool rec)
 {
 #if _WIN32


### PR DESCRIPTION
Have had this commit for awhile (spoke in discord to you about it) and realised I forgot to send it up as I was doing my rebase on latest changes. Unsure if you're okay with this - I don't see any harm in having it in chiaki-ng at least as it allows for hooking into the thread creation process via a callback that will be supplied by the caller. I called it thread affinity, but honestly I wonder if it could be potentially renamed as pthread_create_callback or something along those lines

This is really for weaker platforms and will no-opt by default. The idea is to allow control for anyone looking to use chiaki-ng as a library to add an optional thread affinity in scenarios where core assignment matters for performance (I see there's even a webOS fork now)

It basically allows any callers to intercept the pthread_create calls and do anything that needs to be done after them. On NX, all the pthread_create calls go to core 3 which is heavily used by the system, with this, I've been able to apply a mask to pin the threads to cores that are being underutilized,allowing for improved performance