### PR TITLE
Fix macOS ARM: rendering, crash-on-exit, and controller input

### DIFF
--- a/gui/src/qml/StreamView.qml
+++ b/gui/src/qml/StreamView.qml
@@ -86,7 +86,12 @@ Item {
         property bool closing: false
         property bool open: false
 
+        property real lastToggleTime: 0
         function toggle() {
+            var now = Date.now();
+            if (now - lastToggleTime < 200)
+                return;
+            lastToggleTime = now;
             if (open)
                 close();
             else {

--- a/gui/src/qmlcontroller.cpp
+++ b/gui/src/qmlcontroller.cpp
@@ -2,6 +2,7 @@
 
 #include <QTimer>
 #include <QKeyEvent>
+#include <QDateTime>
 #include <QStyleHints>
 #include <QGuiApplication>
 
@@ -113,6 +114,20 @@ QString QmlController::GetVIDPID() const
 
 void QmlController::sendKey(Qt::Key key, Qt::KeyboardModifiers modifiers)
 {
+    // SDL2-compat/SDL3 on macOS can expose a single physical controller as
+    // two devices, creating two QmlController instances that both fire for
+    // the same button press.  Use a static guard to deduplicate.
+    static Qt::Key lastKey = Qt::Key_unknown;
+    static qint64 lastTime = 0;
+    qint64 now = QDateTime::currentMSecsSinceEpoch();
+    if (key == lastKey && (now - lastTime) < 50) {
+        lastKey = key;
+        lastTime = now;
+        return;
+    }
+    lastKey = key;
+    lastTime = now;
+
     QKeyEvent press(QEvent::KeyPress, key, modifiers);
     QKeyEvent release(QEvent::KeyRelease, key, Qt::NoModifier);
     QGuiApplication::sendEvent(target, &press);

--- a/gui/src/sessionlog.cpp
+++ b/gui/src/sessionlog.cpp
@@ -107,40 +107,81 @@ static void LogCb(ChiakiLogLevel level, const char *msg, void *user)
 	SessionLogPrivate::Log(log, level, msg);
 }
 
+// Heap-allocated regexes that intentionally outlive static destruction,
+// preventing use-after-free when background threads (e.g. takion) log
+// while the process is shutting down.
+static const QRegularExpression &sanitize_ipv4_re()
+{
+	static const auto *re = new QRegularExpression(
+		R"(\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b)");
+	return *re;
+}
+static const QRegularExpression &sanitize_ipv6_re()
+{
+	static const auto *re = new QRegularExpression(
+		R"((?<![0-9A-Za-z])\[?(?:(?:[0-9A-Fa-f]{1,4}:){3,7}[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{0,4}:){0,7}::(?:[0-9A-Fa-f]{0,4}:){0,7}[0-9A-Fa-f]{0,4})\]?(?![0-9A-Za-z]))");
+	return *re;
+}
+static const QRegularExpression &sanitize_labeled_secret_re()
+{
+	static const auto *re = new QRegularExpression(
+		R"((((?:console|host|server|session|account|psn|public|remote)\s+(?:id|ip|address)|duid)\s*:\s*)([^\s,;]+))",
+		QRegularExpression::CaseInsensitiveOption);
+	return *re;
+}
+static const QRegularExpression &sanitize_session_id_token_re()
+{
+	static const auto *re = new QRegularExpression(
+		R"((session\s+id\s+)([A-Za-z0-9+/=_-]{8,}))",
+		QRegularExpression::CaseInsensitiveOption);
+	return *re;
+}
+static const QRegularExpression &sanitize_uuid_re()
+{
+	static const auto *re = new QRegularExpression(
+		R"(\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\b)");
+	return *re;
+}
+static const QRegularExpression &sanitize_long_hex_re()
+{
+	static const auto *re = new QRegularExpression(
+		R"(\b[a-fA-F0-9]{16,}\b)");
+	return *re;
+}
+static const QRegularExpression &sanitize_account_id_re()
+{
+	static const auto *re = new QRegularExpression(
+		R"((account(?:_id)?\s*=\s*)([^\s,;]+))", QRegularExpression::CaseInsensitiveOption);
+	return *re;
+}
+static const QRegularExpression &sanitize_duid_re()
+{
+	static const auto *re = new QRegularExpression(
+		R"((duid\s*=\s*)([^\s,;]+))", QRegularExpression::CaseInsensitiveOption);
+	return *re;
+}
+static const QRegularExpression &sanitize_session_id_eq_re()
+{
+	static const auto *re = new QRegularExpression(
+		R"((session\s+id\s*=\s*)([^\s,;]+))", QRegularExpression::CaseInsensitiveOption);
+	return *re;
+}
+
 static QString SanitizeLogMessage(const QString &msg)
 {
 	QString sanitized = msg;
 
-	static const QRegularExpression ipv4_re(
-		R"(\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b)");
-	static const QRegularExpression ipv6_re(
-		R"((?<![0-9A-Za-z])\[?(?:(?:[0-9A-Fa-f]{1,4}:){3,7}[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{0,4}:){0,7}::(?:[0-9A-Fa-f]{0,4}:){0,7}[0-9A-Fa-f]{0,4})\]?(?![0-9A-Za-z]))");
-	static const QRegularExpression labeled_secret_re(
-		R"((((?:console|host|server|session|account|psn|public|remote)\s+(?:id|ip|address)|duid)\s*:\s*)([^\s,;]+))",
-		QRegularExpression::CaseInsensitiveOption);
-	static const QRegularExpression session_id_token_re(
-		R"((session\s+id\s+)([A-Za-z0-9+/=_-]{8,}))",
-		QRegularExpression::CaseInsensitiveOption);
-	static const QRegularExpression uuid_re(
-		R"(\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\b)");
-	static const QRegularExpression long_hex_re(
-		R"(\b[a-fA-F0-9]{16,}\b)");
-
-	sanitized.replace(ipv4_re, QStringLiteral("<redacted-ipv4>"));
-	sanitized.replace(ipv6_re, QStringLiteral("<redacted-ipv6>"));
-	sanitized.replace(labeled_secret_re, QStringLiteral("\\1<redacted>"));
-
-	sanitized.replace(QRegularExpression(R"((account(?:_id)?\s*=\s*)([^\s,;]+))", QRegularExpression::CaseInsensitiveOption),
-	                  QStringLiteral("\\1<redacted>"));
-	sanitized.replace(QRegularExpression(R"((duid\s*=\s*)([^\s,;]+))", QRegularExpression::CaseInsensitiveOption),
-	                  QStringLiteral("\\1<redacted>"));
-	sanitized.replace(QRegularExpression(R"((session\s+id\s*=\s*)([^\s,;]+))", QRegularExpression::CaseInsensitiveOption),
-	                  QStringLiteral("\\1<redacted>"));
-	sanitized.replace(session_id_token_re, QStringLiteral("\\1<redacted>"));
-	sanitized.replace(uuid_re, QStringLiteral("<redacted-uuid>"));
+	sanitized.replace(sanitize_ipv4_re(), QStringLiteral("<redacted-ipv4>"));
+	sanitized.replace(sanitize_ipv6_re(), QStringLiteral("<redacted-ipv6>"));
+	sanitized.replace(sanitize_labeled_secret_re(), QStringLiteral("\\1<redacted>"));
+	sanitized.replace(sanitize_account_id_re(), QStringLiteral("\\1<redacted>"));
+	sanitized.replace(sanitize_duid_re(), QStringLiteral("\\1<redacted>"));
+	sanitized.replace(sanitize_session_id_eq_re(), QStringLiteral("\\1<redacted>"));
+	sanitized.replace(sanitize_session_id_token_re(), QStringLiteral("\\1<redacted>"));
+	sanitized.replace(sanitize_uuid_re(), QStringLiteral("<redacted-uuid>"));
 
 	// Catch unlabeled long hex identifiers, which commonly occur in console IDs and device UIDs.
-	sanitized.replace(long_hex_re, QStringLiteral("<redacted-hex>"));
+	sanitized.replace(sanitize_long_hex_re(), QStringLiteral("<redacted-hex>"));
 
 	return sanitized;
 }

--- a/gui/src/settings.cpp
+++ b/gui/src/settings.cpp
@@ -597,8 +597,8 @@ static const QMap<RenderBackend, QString> render_backend_values = {
 	{ RenderBackend::OpenGL, "opengl" },
 };
 
-#if defined(Q_OS_MACOS)
-// Default to OpenGL on macOS due to Qt 6.10 bug with MoltenVK
+#if defined(Q_OS_MACOS) && QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+// Default to OpenGL on macOS with Qt >= 6.10 due to MoltenVK bug
 static const RenderBackend render_backend_default = RenderBackend::OpenGL;
 #else
 static const RenderBackend render_backend_default = RenderBackend::Vulkan;
@@ -609,8 +609,8 @@ RenderBackend Settings::GetRenderBackend() const
 	auto v = settings.value("settings/render_backend", render_backend_values[render_backend_default]).toString();
 	auto backend = render_backend_values.key(v, render_backend_default);
 
-#if defined(Q_OS_MACOS)
-	// Force OpenGL on macOS because the Qt 6.10 MoltenVK backend crashes when it creates a QContainerLayer.
+#if defined(Q_OS_MACOS) && QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+	// Force OpenGL on macOS with Qt >= 6.10 because MoltenVK backend crashes when it creates a QContainerLayer.
 	if (backend == RenderBackend::Vulkan) {
 		qWarning() << "Forcing OpenGL backend on macOS (Vulkan unavailable because of Qt 6.10 MoltenVK bug)";
 		return RenderBackend::OpenGL;


### PR DESCRIPTION
## Summary

Fixes several issues affecting macOS ARM (Apple Silicon) users:

- **Vulkan renderer now allowed on macOS with Qt < 6.10** — The existing code unconditionally forced OpenGL on all macOS builds to work around a Qt 6.10 MoltenVK bug. This made the forced-OpenGL apply even on Qt 6.9.x where Vulkan/MoltenVK works correctly. On Apple Silicon, OpenGL is deprecated and runs through a buggy Metal translation layer, causing blue screens and rendering failures. The fix makes the override conditional on `QT_VERSION >= 6.10.0`.

- **Fix crash-on-exit in SessionLog (all platforms)** — Background threads (e.g. takion protocol) could call `SessionLog::Log()` → `SanitizeLogMessage()` during process shutdown, accessing `static const QRegularExpression` objects that were already destroyed by static destructors. Fixed by heap-allocating the regex objects so they intentionally outlive static destruction.

- **Fix duplicate controller input on macOS with SDL2-compat/SDL3** — SDL2-compat (SDL3 backend) on macOS exposes a single physical controller as two SDL devices, creating two `QmlController` instances that both fire for the same button press. This caused double-navigation in menus and could trigger duplicate stream session starts. Fixed with a static timestamp-based deduplication guard in `sendKey()`.

- **Fix stream menu toggle firing twice** — The controller shortcut combo (L1+R1+L3+R3) and synthesized Ctrl+O key events could trigger `menuController.toggle()` twice in rapid succession (open then immediately close). Added a 200ms debounce guard.

## Testing

Tested on MacBook Pro M1 Pro (macOS 26.4) with:
- DualSense controller via Bluetooth
- Qt 6.9.3, FFmpeg 8.0.1, libplacebo 7.351.0, MoltenVK 1.4.1
- PS5 remote play streaming (local network)
- Verified: video rendering, stream menu overlay, controller navigation, in-game controller input