### PR TITLE
upnp: do work in seperate thread with a timeout, also, fix a bug in the conditional check for upnp discover

### DIFF
--- a/lib/src/remote/holepunch.c
+++ b/lib/src/remote/holepunch.c
@@ -334,6 +334,8 @@ typedef struct session_t
     size_t num_stun_servers_ipv6;
     UPNPGatewayInfo gw;
     UPNPGatewayStatus gw_status;
+    ChiakiThread upnp_thread;
+    bool upnp_thread_running;
 
     uint8_t data1[16];
     uint8_t data2[16];
@@ -771,6 +773,7 @@ CHIAKI_EXPORT Session* chiaki_holepunch_session_init(
     session->num_stun_servers_ipv6 = 0;
     session->gw.data = NULL;
     session->gw_status = GATEWAY_STATUS_UNKNOWN;
+    session->upnp_thread_running = false;
 
     ChiakiErrorCode err;
     err = chiaki_mutex_init(&session->notif_mutex, false);
@@ -810,6 +813,30 @@ CHIAKI_EXPORT Session* chiaki_holepunch_session_init(
     return session;
 }
 
+#define UPNP_DISCOVER_TIMEOUT_MS 7000
+
+static void *upnp_discover_thread_func(void *arg)
+{
+    Session *session = (Session *)arg;
+    ChiakiErrorCode err = upnp_get_gateway_info(session->log, &session->gw);
+
+    chiaki_mutex_lock(&session->state_mutex);
+    if (err == CHIAKI_ERR_SUCCESS)
+        session->gw_status = GATEWAY_STATUS_FOUND;
+    else
+    {
+        session->gw_status = GATEWAY_STATUS_NOT_FOUND;
+        free(session->gw.data);
+        session->gw.data = NULL;
+        free(session->gw.urls);
+        session->gw.urls = NULL;
+    }
+    session->upnp_thread_running = false;
+    chiaki_cond_signal(&session->state_cond);
+    chiaki_mutex_unlock(&session->state_mutex);
+    return NULL;
+}
+
 CHIAKI_EXPORT ChiakiErrorCode chiaki_holepunch_upnp_discover(Session *session)
 {
     session->gw.data = calloc(1, sizeof(struct IGDdatas));
@@ -823,17 +850,45 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_holepunch_upnp_discover(Session *session)
         free(session->gw.data);
         return CHIAKI_ERR_MEMORY;
     }
-    ChiakiErrorCode err = upnp_get_gateway_info(session->log, &session->gw);
-    if (err == CHIAKI_ERR_SUCCESS)
-        session->gw_status = GATEWAY_STATUS_FOUND;
-    else
+
+    session->upnp_thread_running = true;
+    ChiakiErrorCode err = chiaki_thread_create(&session->upnp_thread, upnp_discover_thread_func, session);
+    if(err != CHIAKI_ERR_SUCCESS)
     {
-        session->gw_status = GATEWAY_STATUS_NOT_FOUND;
-        free(session->gw.data);
-        session->gw.data = NULL;
-        free(session->gw.urls);
-        session->gw.urls = NULL;
+        CHIAKI_LOGE(session->log, "Failed to create UPnP discovery thread, falling back to synchronous");
+        session->upnp_thread_running = false;
+        err = upnp_get_gateway_info(session->log, &session->gw);
+        if (err == CHIAKI_ERR_SUCCESS)
+            session->gw_status = GATEWAY_STATUS_FOUND;
+        else
+        {
+            session->gw_status = GATEWAY_STATUS_NOT_FOUND;
+            free(session->gw.data);
+            session->gw.data = NULL;
+            free(session->gw.urls);
+            session->gw.urls = NULL;
+        }
+        return CHIAKI_ERR_SUCCESS;
     }
+
+    chiaki_mutex_lock(&session->state_mutex);
+    while(session->upnp_thread_running)
+    {
+        err = chiaki_cond_timedwait(&session->state_cond, &session->state_mutex, UPNP_DISCOVER_TIMEOUT_MS);
+        if(err == CHIAKI_ERR_TIMEOUT)
+            break;
+    }
+
+    if(session->upnp_thread_running)
+    {
+        chiaki_mutex_unlock(&session->state_mutex);
+        CHIAKI_LOGW(session->log, "UPnP discovery timed out after %d ms, skipping", UPNP_DISCOVER_TIMEOUT_MS);
+        session->gw_status = GATEWAY_STATUS_NOT_FOUND;
+        return CHIAKI_ERR_SUCCESS;
+    }
+    chiaki_mutex_unlock(&session->state_mutex);
+
+    chiaki_thread_join(&session->upnp_thread, NULL);
     return CHIAKI_ERR_SUCCESS;
 }
 
@@ -1723,6 +1778,12 @@ CHIAKI_EXPORT void chiaki_holepunch_session_fini(Session* session)
         chiaki_stop_pipe_stop(&session->select_pipe);
         chiaki_thread_join(&session->ws_thread, NULL);
     }
+    if(session->upnp_thread_running)
+    {
+        CHIAKI_LOGI(session->log, "Waiting for UPnP discovery thread to finish...");
+        chiaki_thread_join(&session->upnp_thread, NULL);
+        session->upnp_thread_running = false;
+    }
     if(session->gw.data)
     {
         if(session->local_port_ctrl != 0)
@@ -1737,7 +1798,7 @@ CHIAKI_EXPORT void chiaki_holepunch_session_fini(Session* session)
             if(upnp_delete_udp_port_mapping(session->log, &session->gw, session->local_port_data))
                 CHIAKI_LOGI(session->log, "Deleted UPNP local port data mapping");
             else
-                CHIAKI_LOGE(session->log, "Couldn't delete UPNP local port data mapping"); 
+                CHIAKI_LOGE(session->log, "Couldn't delete UPNP local port data mapping");
         }
         free(session->gw.data);
         free(session->gw.urls);
@@ -3508,27 +3569,25 @@ static ChiakiErrorCode get_client_addr_local(Session *session, Candidate *local_
  */
 static ChiakiErrorCode upnp_get_gateway_info(ChiakiLog *log, UPNPGatewayInfo *info)
 {
-    ChiakiErrorCode err = CHIAKI_ERR_SUCCESS;
     int success = 0;
     struct UPNPDev *devlist = upnpDiscover(
         2000 /** ms, delay*/, NULL, NULL, 0, 0, 2, &success);
-    if (devlist == NULL || err != UPNPDISCOVER_SUCCESS) {
-        CHIAKI_LOGI(log, "Failed to find UPnP-capable devices on network: err=%d", err);
+    if (devlist == NULL || success != UPNPDISCOVER_SUCCESS) {
+        CHIAKI_LOGI(log, "Failed to find UPnP-capable devices on network: err=%d", success);
         return CHIAKI_ERR_NETWORK;
     }
 
+    ChiakiErrorCode err = CHIAKI_ERR_SUCCESS;
 #if MINIUPNPC_API_VERSION >= 18
-    success = UPNP_GetValidIGD(devlist, info->urls, info->data, info->lan_ip, sizeof(info->lan_ip), NULL, 0);
+    int igd_ret = UPNP_GetValidIGD(devlist, info->urls, info->data, info->lan_ip, sizeof(info->lan_ip), NULL, 0);
 #else
-    success = UPNP_GetValidIGD(devlist, info->urls, info->data, info->lan_ip, sizeof(info->lan_ip));
+    int igd_ret = UPNP_GetValidIGD(devlist, info->urls, info->data, info->lan_ip, sizeof(info->lan_ip));
 #endif
-    if (success != 1) {
-        CHIAKI_LOGI(log, "Failed to discover internet gateway via UPnP: err=%d", err);
+    if (igd_ret != 1) {
+        CHIAKI_LOGI(log, "Failed to discover internet gateway via UPnP: err=%d", igd_ret);
         err = CHIAKI_ERR_NETWORK;
-        goto cleanup;
     }
 
-cleanup:
     freeUPNPDevlist(devlist);
     return err;
 }


### PR DESCRIPTION
Got this log from one of my users today:

```
09:42:05.131[0;34m[INFO][0m Connect to ps5 (Remote)
09:42:05.158[0;34m[INFO][0m Switched to connection log: sdmc:/switch/akira/logs/100426_094205_remote.log
09:42:05.158[0;34m[INFO][0m ========================================
09:42:05.158[0;34m[INFO][0m CONNECTION ATTEMPT: remote to ps5 (Remote)
09:42:05.158[0;34m[INFO][0m ========================================
09:42:05.158[0;34m[INFO][0m Thread 'connection' pinned to core 2
09:42:05.158[0;34m[INFO][0m Connection thread started
09:42:05.158[0;34m[INFO][0m Initiating holepunch connection...
09:42:05.174[0;34m[INFO][0m Holepunch session state: 1 = [ ✅INIT ]
09:42:05.174[0;34m[INFO][0m Port guessing enabled: 75 guesses, 120 sockets
09:42:05.174[0;34m[INFO][0m Holepunch session initialized for ps5 (Remote)
09:42:05.174[0;34m[INFO][0m Starting holepunch connection sequence for ps5 (Remote) (PS5) - attempt 1/4
09:43:08.683[0;34m[INFO][0m AppletHook received: 0 (OnFocusState)
09:43:08.683[0;34m[INFO][0m AppletFocusState_OutOfFocus
```

Just a couple of things:

```
- ChiakiErrorCode err = CHIAKI_ERR_SUCCESS;
  int success = 0;
  struct UPNPDev *devlist = upnpDiscover(
      2000 /** ms, delay*/, NULL, NULL, 0, 0, 2, &success);
- if (devlist == NULL || err != UPNPDISCOVER_SUCCESS) {
-     CHIAKI_LOGI(log, "Failed to find UPnP-capable devices on network: err=%d", err);
+ if (devlist == NULL || success != UPNPDISCOVER_SUCCESS) {
+     CHIAKI_LOGI(log, "Failed to find UPnP-capable devices on network: err=%d", success);
      return CHIAKI_ERR_NETWORK;
  }

```
I dont think err != UPNDISCOVER_SUCCESS would ever trigger, err doesnt seem to be modified by `upnpDiscover`?

Second thing is that to avoid miniupnpc blocking forever, do the work seperately in another thread, and exit when a predefined timeout is reached (7s). Specifically, I think where it was being blocked is in `UPNP_GetValidIGD`, but I'm not too sure exactly where this was blocked on as I was relying on user reports to debug this.

Clean up during session teardown.

Assuming the above, here's what it looks like:

```
9:04:33.338[0;34m[INFO][0m Connection thread started
19:04:33.338[0;34m[INFO][0m Initiating holepunch connection...
19:04:33.344[0;34m[INFO][0m Holepunch session state: 1 = [ ✅INIT ]
19:04:33.344[0;34m[INFO][0m Port guessing enabled: 75 guesses, 120 sockets
19:04:33.344[0;34m[INFO][0m Holepunch session initialized for ps5 (Remote)
19:04:33.344[0;34m[INFO][0m Starting holepunch connection sequence for ps5 (Remote) (PS5) - attempt 1/4
19:04:40.345[0;33m[WARNING][0m UPnP discovery timed out after 7000 ms, skipping
19:04:40.345[0;34m[INFO][0m UPNP discovery completed
19:04:40.345[0;34m[INFO][0m Creating holepunch session on PSN...
19:04:40.998[0;34m[INFO][0m Thread 'holepunch' pinned to core 0
19:04:40.998[0;34m[INFO][0m chiaki_holepunch_session_create: Created websocket thread
19:04:40.998[0;34m[INFO][0m chiaki_holepunch_session_create: Waiting for websocket to open...
19:04:41.592[0;34m[INFO][0m websocket_thread_func: Connected to push notification WebSocket wss://44-234-164-207-pushcl.np.communication.playstation.net/np/pushNotification
19:04:41.592[0;34m[INFO][0m Holepunch session state: 3 = [ ✅INIT ✅WS_OPEN ]
19:04:41.593[0;34m[INFO][0m http_create_session: Sending JSON:
{"remotePlaySessions":[{"members":[{"accountId":"me","deviceUniqueId":"me","platform":"me","pushContexts":[{"pushContextId":"...."}]}]}]}
19:04:41.593[0;34m[INFO][0m websocket_thread_func: PING.
19:04:41.718[0;34m[INFO][0m websocket_thread_func: Received WebSocket frame of length 0 with flags 64
19:04:41.718[0;34m[INFO][0m websocket_thread_func: Received PONG.
19:04:41.820[0;34m[INFO][0m websocket_thread_func: Received WebSocket frame of length 560 with flags 1
19:04:41.821[0;34m[INFO][0m websocket_thread_func: Received WebSocket frame with 560 bytes of payload.
```