### PR TITLE
fix for ffmpeg v9(#795), but also keeps support for v <7.1

### DIFF
--- a/gui/src/qmlmainwindow.cpp
+++ b/gui/src/qmlmainwindow.cpp
@@ -4637,6 +4637,39 @@ AVBufferRef *QmlMainWindow::vulkanHwDeviceCtx()
     vkctx->nb_enabled_inst_extensions = placebo_vk_inst->num_extensions;
     vkctx->enabled_dev_extensions = placebo_vulkan->extensions;
     vkctx->nb_enabled_dev_extensions = placebo_vulkan->num_extensions;
+
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(59, 34, 100)
+    vkctx->nb_qf = 0;
+    if (placebo_vulkan->queue_graphics.index >= 0 && placebo_vulkan->queue_graphics.count > 0) {
+        AVVulkanDeviceQueueFamily &qf = vkctx->qf[vkctx->nb_qf++];
+        qf.idx = placebo_vulkan->queue_graphics.index;
+        qf.num = placebo_vulkan->queue_graphics.count;
+        qf.flags = VK_QUEUE_GRAPHICS_BIT;
+        qf.video_caps = static_cast<VkVideoCodecOperationFlagBitsKHR>(0);
+    }
+    if (placebo_vulkan->queue_transfer.index >= 0 && placebo_vulkan->queue_transfer.count > 0) {
+        AVVulkanDeviceQueueFamily &qf = vkctx->qf[vkctx->nb_qf++];
+        qf.idx = placebo_vulkan->queue_transfer.index;
+        qf.num = placebo_vulkan->queue_transfer.count;
+        qf.flags = VK_QUEUE_TRANSFER_BIT;
+        qf.video_caps = static_cast<VkVideoCodecOperationFlagBitsKHR>(0);
+    }
+    if (placebo_vulkan->queue_compute.index >= 0 && placebo_vulkan->queue_compute.count > 0) {
+        AVVulkanDeviceQueueFamily &qf = vkctx->qf[vkctx->nb_qf++];
+        qf.idx = placebo_vulkan->queue_compute.index;
+        qf.num = placebo_vulkan->queue_compute.count;
+        qf.flags = VK_QUEUE_COMPUTE_BIT;
+        qf.video_caps = static_cast<VkVideoCodecOperationFlagBitsKHR>(0);
+    }
+    if (vk_decode_queue_index >= 0) {
+        AVVulkanDeviceQueueFamily &qf = vkctx->qf[vkctx->nb_qf++];
+        qf.idx = vk_decode_queue_index;
+        qf.num = 1;
+        qf.flags = VK_QUEUE_VIDEO_DECODE_BIT_KHR;
+        qf.video_caps = static_cast<VkVideoCodecOperationFlagBitsKHR>(
+            VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR | VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR);
+    }
+#else
     vkctx->queue_family_index = placebo_vulkan->queue_graphics.index;
     vkctx->nb_graphics_queues = placebo_vulkan->queue_graphics.count;
     vkctx->queue_family_tx_index = placebo_vulkan->queue_transfer.index;
@@ -4645,6 +4678,8 @@ AVBufferRef *QmlMainWindow::vulkanHwDeviceCtx()
     vkctx->nb_comp_queues = placebo_vulkan->queue_compute.count;
     vkctx->queue_family_decode_index = vk_decode_queue_index;
     vkctx->nb_decode_queues = 1;
+#endif
+
     vkctx->lock_queue = [](struct AVHWDeviceContext *dev_ctx, uint32_t queue_family, uint32_t index) {
         auto vk = reinterpret_cast<pl_vulkan>(dev_ctx->user_opaque);
         vk->lock_queue(vk, queue_family, index);


### PR DESCRIPTION
## Fix for FFMPEG 9(#795)

FFmpeg 9.0 removed several fields from the AVVulkanDeviceContext struct (queue_family_index, nb_graphics_queues, queue_family_tx_index, etc.) that chiaki-ng used to set up Vulkan hardware video decoding. In their place, FFmpeg 7.1+ introduced a unified qf[]/nb_qf array (each entry describing one queue family: index, count, and usage flags).
* If built with ffmpeg 7.1 or newer it will use the new AVVulkanDeviceContext struct arrays
* else it falls back to the original individual fields, unchached
