### PR TITLE
fix(gui): fix use-after-free crashes on session teardown, controller …

### DIFF
--- a/gui/include/qmlbackend.h
+++ b/gui/include/qmlbackend.h
@@ -281,6 +281,7 @@ private:
     uint32_t getStreamShortcut() const;
     void updateStreamShortcut();
     QString getExecutable();
+    void teardownSession();
 
     Settings *settings = {};
     QmlSettings *settings_qml = {};

--- a/gui/src/qmlbackend.cpp
+++ b/gui/src/qmlbackend.cpp
@@ -485,14 +485,7 @@ bool QmlBackend::prepareFrameForPresentation(ChiakiFfmpegFrame &frame, bool use_
 
 QmlBackend::~QmlBackend()
 {
-    if(session)
-    {
-        chiaki_log_mutex.lock();
-        chiaki_log_ctx = nullptr;
-        chiaki_log_mutex.unlock();
-        session->deleteLater();
-        session = nullptr;
-    }
+    teardownSession();
 #ifdef CHIAKI_HAVE_WEBENGINE
     if(request_interceptor)
         request_interceptor->deleteLater();
@@ -502,6 +495,34 @@ QmlBackend::~QmlBackend()
     frame_thread->parent()->deleteLater();
     psn_connection_thread.quit();
     psn_connection_thread.wait();
+}
+
+void QmlBackend::teardownSession()
+{
+    if (!session)
+        return;
+
+    chiaki_log_mutex.lock();
+    chiaki_log_ctx = nullptr;
+    chiaki_log_mutex.unlock();
+
+    // 1) Stop any new signal deliveries from the session, most importantly the
+    //    frame-thread FfmpegFrameAvailable handler.
+    session->disconnect();
+
+    // 2) Drain the frame thread's already-queued lambdas. QMetaObject::invoke
+    //    queues this barrier *after* any in-flight FfmpegFrameAvailable call, so
+    //    blocking until it runs guarantees no handler still touches `session`
+    //    before we schedule its deletion below. Without this, deleteLater's
+    //    asynchronous free races the frame thread reading `session`, which is the
+    //    use-after-free crash in session->GetFfmpegDecoder().
+    if (QObject *frame_ctx = frame_thread ? frame_thread->parent() : nullptr) {
+        QMetaObject::invokeMethod(frame_ctx, []() {}, Qt::BlockingQueuedConnection);
+    }
+
+    // 3) Safe now: schedule the deferred delete and drop the member.
+    session->deleteLater();
+    session = nullptr;
 }
 
 QmlMainWindow *QmlBackend::qmlWindow() const
@@ -864,39 +885,18 @@ void QmlBackend::checkPsnConnection(const ChiakiErrorCode &err)
             break;
         case CHIAKI_ERR_HOST_DOWN:
             setConnectState(PsnConnectState::ConnectFailedStart);
-            if(session)
-            {
-                chiaki_log_mutex.lock();
-                chiaki_log_ctx = nullptr;
-                chiaki_log_mutex.unlock();
-                session->deleteLater();
-                session = nullptr;
-                setDiscoveryEnabled(true);
-            }
+            teardownSession();
+            setDiscoveryEnabled(true);
             break;
         case CHIAKI_ERR_HOST_UNREACH:
             setConnectState(PsnConnectState::ConnectFailedConsoleUnreachable);
-            if(session)
-            {
-                chiaki_log_mutex.lock();
-                chiaki_log_ctx = nullptr;
-                chiaki_log_mutex.unlock();
-                session->deleteLater();
-                session = nullptr;
-                setDiscoveryEnabled(true);
-            }
+            teardownSession();
+            setDiscoveryEnabled(true);
             break;
         default:
             setConnectState(PsnConnectState::ConnectFailed);
-            if(session)
-            {
-                chiaki_log_mutex.lock();
-                chiaki_log_ctx = nullptr;
-                chiaki_log_mutex.unlock();
-                session->deleteLater();
-                session = nullptr;
-                setDiscoveryEnabled(true);
-            }
+            teardownSession();
+            setDiscoveryEnabled(true);
             break;
     }
 }
@@ -918,17 +918,12 @@ void QmlBackend::startSession(bool emit_session_changed)
     try {
         session->Start();
     } catch (const Exception &e) {
-        StreamSession *failed_session = session;
-        session = nullptr;
-        chiaki_log_mutex.lock();
-        chiaki_log_ctx = nullptr;
-        chiaki_log_mutex.unlock();
         if (window) {
-            emit sessionChanged(nullptr);
             window->resetPlaceboQueue();
             window->requestOverlayUpdate();
         }
-        failed_session->deleteLater();
+        teardownSession();
+        emit sessionChanged(nullptr);
         emit error(tr("Stream failed"), tr("Failed to start Stream Session: %1").arg(e.what()));
         return;
     }
@@ -1165,8 +1160,7 @@ void QmlBackend::createSession(const StreamSessionConnectInfo &connect_info)
             logged_hw_transfer_failures.clear();
         }
 
-        session_for_connections->deleteLater();
-        session = nullptr;
+        teardownSession();
         emit sessionChanged(session);
 
         sleep_inhibit->release();
@@ -1719,12 +1713,7 @@ void QmlBackend::stopAutoConnect()
         if(wakeup_start)
         {
             wakeup_start = false;
-            chiaki_log_mutex.lock();
-            chiaki_log_ctx = nullptr;
-            chiaki_log_mutex.unlock();
-
-            session->deleteLater();
-            session = nullptr;
+            teardownSession();
         }
     }
     emit autoConnectChanged();

--- a/gui/src/qmlmainwindow.cpp
+++ b/gui/src/qmlmainwindow.cpp
@@ -2647,6 +2647,11 @@ QmlMainWindow::~QmlMainWindow()
     pl_cache_destroy(&placebo_cache);
     pl_queue_destroy(&placebo_queue);
     pl_renderer_destroy(&placebo_renderer);
+    // User shader hooks hold a reference to the GPU (their descriptors destroy
+    // buffers/textures via p->gpu), so they must be released before the GPU is.
+    pl_mpv_user_shader_destroy(&fsr_hook);
+    pl_mpv_user_shader_destroy(&fsrcnnx_hook_8);
+    pl_mpv_user_shader_destroy(&fsrcnnx_hook_16);
     if (render_backend == RenderBackend::Vulkan) {
         pl_vulkan_destroy(&placebo_vulkan);
         pl_vk_inst_destroy(&placebo_vk_inst);
@@ -2657,9 +2662,6 @@ QmlMainWindow::~QmlMainWindow()
     delete qt_gl_offscreen_surface;
     delete qt_gl_context;
     pl_options_free(&renderparams_opts);
-    pl_mpv_user_shader_destroy(&fsr_hook);
-    pl_mpv_user_shader_destroy(&fsrcnnx_hook_8);
-    pl_mpv_user_shader_destroy(&fsrcnnx_hook_16);
     pl_log_destroy(&placebo_log);
 }
 

--- a/gui/src/streamsession.cpp
+++ b/gui/src/streamsession.cpp
@@ -1188,7 +1188,12 @@ void StreamSession::UpdateGamepads()
 			{
 				haptics_handheld--;
 			}
-			QTimer::singleShot(1000, this, [this, controller] {
+			QTimer::singleShot(1000, this, [this, controller_id] {
+				// The controller may have been removed (and released) before this fires
+				// (e.g. a quick disconnect), so re-look it up instead of capturing a raw pointer.
+				auto controller = controllers.value(controller_id);
+				if(!controller)
+					return;
 				controller->ChangePlayerIndex(player_index);
 				controller->ChangeLEDColor(led_color);
 			});


### PR DESCRIPTION
…disconnect, and exit

Route every StreamSession teardown through teardownSession(): disconnect signals, drain in-flight frame-thread handlers via a BlockingQueuedConnection barrier, then delete deferred. Fixes a frame-thread UAF on session->GetFfmpegDecoder() during teardown.

UpdateGamepads: capture controller id instead of a raw Controller* in the delayed 1s lambda, re-lookup by id at run time. Fixes a UAF on quick controller disconnect.

Destroy libplacebo user shader hooks before pl_vulkan/pl_opengl teardown, since hook descriptors are freed via the GPU.