### PR TITLE
fix(gui): DualSense haptics, gyro, and Bluetooth reliability fixes

### DIFF
--- a/gui/include/controllermanager.h
+++ b/gui/include/controllermanager.h
@@ -37,6 +37,7 @@ class ControllerManager : public QObject
 		bool is_app_active;
 		bool moved;
 		uint8_t dualsense_intensity;
+		bool ds5_gyro_fix_enabled;
 
 		void ControllerClosed(Controller *controller);
 		void CheckMoved();
@@ -58,6 +59,8 @@ class ControllerManager : public QObject
 		void SetIsAppActive(bool active);
 		void SetDualSenseIntensity(uint8_t intensity) { dualsense_intensity = intensity; };
 		uint8_t GetDualSenseIntensity() { return dualsense_intensity; };
+		void SetDS5GyroFixEnabled(bool enabled) { ds5_gyro_fix_enabled = enabled; };
+		bool GetDS5GyroFixEnabled() { return ds5_gyro_fix_enabled; };
 		void creatingControllerMapping(bool creating_controller_mapping);
 		QSet<int> GetAvailableControllers();
 		Controller *OpenController(int device_id);
@@ -128,6 +131,8 @@ class Controller : public QObject
 		bool IsPS();
 		QString GetGUIDString();
 		ChiakiControllerState GetState();
+		// True when the controller reports a wired (USB) power source.
+		bool IsWired();
 		void SetRumble(uint8_t left, uint8_t right);
 		void SetTriggerEffects(uint8_t type_left, const uint8_t *data_left, uint8_t type_right, const uint8_t *data_right);
 		void SetDualsenseMic(bool on);

--- a/gui/include/qmlsettings.h
+++ b/gui/include/qmlsettings.h
@@ -33,6 +33,9 @@ class QmlSettings : public QObject
     Q_PROPERTY(bool showStreamStats READ showStreamStats WRITE setShowStreamStats NOTIFY showStreamStatsChanged)
     Q_PROPERTY(bool streamerMode READ streamerMode WRITE setStreamerMode NOTIFY streamerModeChanged)
     Q_PROPERTY(float hapticOverride READ hapticOverride WRITE setHapticOverride NOTIFY hapticOverrideChanged)
+    Q_PROPERTY(bool ds5GyroFix READ ds5GyroFix WRITE setDS5GyroFix NOTIFY ds5GyroFixChanged)
+    Q_PROPERTY(bool hapticsAntiLatency READ hapticsAntiLatency WRITE setHapticsAntiLatency NOTIFY hapticsAntiLatencyChanged)
+    Q_PROPERTY(int hapticsAntiLatencyMs READ hapticsAntiLatencyMs WRITE setHapticsAntiLatencyMs NOTIFY hapticsAntiLatencyMsChanged)
     Q_PROPERTY(int displayTargetContrast READ displayTargetContrast WRITE setDisplayTargetContrast NOTIFY displayTargetContrastChanged)
     Q_PROPERTY(int displayTargetPeak READ displayTargetPeak WRITE setDisplayTargetPeak NOTIFY displayTargetPeakChanged)
     Q_PROPERTY(int displayTargetPrim READ displayTargetPrim WRITE setDisplayTargetPrim NOTIFY displayTargetPrimChanged)
@@ -254,6 +257,15 @@ public:
 
     float hapticOverride() const;
     void setHapticOverride(float override);
+
+    bool ds5GyroFix() const;
+    void setDS5GyroFix(bool enabled);
+
+    bool hapticsAntiLatency() const;
+    void setHapticsAntiLatency(bool enabled);
+
+    int hapticsAntiLatencyMs() const;
+    void setHapticsAntiLatencyMs(int ms);
 
     int fpsLocalPS4() const;
     void setFpsLocalPS4(int fps);
@@ -636,6 +648,9 @@ signals:
     void addSteamShortcutAskChanged();
     void hideCursorChanged();
     void hapticOverrideChanged();
+    void ds5GyroFixChanged();
+    void hapticsAntiLatencyChanged();
+    void hapticsAntiLatencyMsChanged();
     void audioVideoDisabledChanged();
     void showStreamStatsChanged();
     void streamerModeChanged();

--- a/gui/include/settings.h
+++ b/gui/include/settings.h
@@ -305,6 +305,15 @@ class Settings : public QObject
 		float GetHapticOverride() const 			{ return settings.value("settings/haptic_override", 1.0).toFloat(); }
 		void SetHapticOverride(float override)	{ settings.setValue("settings/haptic_override", override); }
 
+		bool GetDS5GyroFixEnabled() const       { return settings.value("settings/ds5_gyro_fix", false).toBool(); }
+		void SetDS5GyroFixEnabled(bool enabled) { settings.setValue("settings/ds5_gyro_fix", enabled); }
+
+		bool GetHapticsAntiLatencyEnabled() const       { return settings.value("settings/haptics_anti_latency", true).toBool(); }
+		void SetHapticsAntiLatencyEnabled(bool enabled) { settings.setValue("settings/haptics_anti_latency", enabled); }
+
+		int GetHapticsAntiLatencyMs() const       { return settings.value("settings/haptics_anti_latency_ms", 50).toInt(); }
+		void SetHapticsAntiLatencyMs(int ms) { settings.setValue("settings/haptics_anti_latency_ms", ms); }
+
 		ChiakiVideoResolutionPreset GetResolutionLocalPS4() const;
 		ChiakiVideoResolutionPreset GetResolutionRemotePS4() const;
 		ChiakiVideoResolutionPreset GetResolutionLocalPS5() const;

--- a/gui/include/streamsession.h
+++ b/gui/include/streamsession.h
@@ -100,6 +100,8 @@ class SdeckHapticsWorker;
 		float haptic_override;
 		ChiakiDisableAudioVideo audio_video_disabled;
 		RumbleHapticsIntensity rumble_haptics_intensity;
+		bool haptics_anti_latency;
+		int haptics_anti_latency_ms;
 		bool buttons_by_pos;
 		bool enable_idr_on_fec_failure;
 		bool start_mic_unmuted;
@@ -218,6 +220,11 @@ class StreamSession : public QObject
 		QQueue<uint16_t> rumble_haptics;
 		bool rumble_haptics_connected;
 		bool rumble_haptics_on;
+		float rumble_haptics_baseline;
+		// Timestamp (monotonic ms) of the last haptics-audio-device reopen
+		// attempt, to rate-limit retries when a wired DualSense is present but
+		// the haptic audio device failed to open (e.g. after USB/BT hot-swap).
+		uint64_t haptics_retry_timestamp_ms = 0;
 		float PS_TOUCHPAD_MAX_X, PS_TOUCHPAD_MAX_Y;
 		ChiakiControllerState keyboard_state;
 		ChiakiControllerState touch_state;
@@ -266,6 +273,8 @@ class StreamSession : public QObject
 		bool audio_out_drain_thread_running = false;
 		bool audio_out_drain_requested = false;
 		size_t haptics_buffer_size;
+		bool haptics_anti_latency;
+		int haptics_anti_latency_ms;
 		unsigned int audio_buffer_size;
 		ChiakiHolepunchSession holepunch_session;
 #if CHIAKI_GUI_ENABLE_SPEEX

--- a/gui/src/controllermanager.cpp
+++ b/gui/src/controllermanager.cpp
@@ -10,6 +10,14 @@
 #include <SDL.h>
 #endif
 
+// SDL renamed the joystick power-level getter in 2.24.0; map to the correct
+// symbol based on the compiled SDL version.
+#if SDL_VERSION_ATLEAST(2, 24, 0)
+#define CHIAKI_SDL_JOYSTICK_GET_POWERLEVEL(js) SDL_JoystickCurrentPowerLevel(js)
+#else
+#define CHIAKI_SDL_JOYSTICK_GET_POWERLEVEL(js) SDL_JoystickGetPowerLevel(js)
+#endif
+
 /* PS5 trigger effect documentation:
    https://controllers.fandom.com/wiki/Sony_DualSense#FFB_Trigger_Modes
 
@@ -140,7 +148,7 @@ ControllerManager *ControllerManager::GetInstance()
 
 ControllerManager::ControllerManager(QObject *parent)
 	: QObject(parent), creating_controller_mapping(false),
-	joystick_allow_background_events(true), dualsense_intensity(0x00), is_app_active(true)
+	joystick_allow_background_events(true), dualsense_intensity(0x00), ds5_gyro_fix_enabled(false), is_app_active(true)
 {
 #ifdef CHIAKI_GUI_ENABLE_SDL_GAMECONTROLLER
 	SDL_SetMainReady();
@@ -608,6 +616,9 @@ inline bool Controller::HandleAxisEvent(SDL_ControllerAxisEvent event) {
 #if SDL_VERSION_ATLEAST(2, 0, 14)
 inline bool Controller::HandleSensorEvent(SDL_ControllerSensorEvent event)
 {
+	bool ds5_fix = manager->GetDS5GyroFixEnabled() && IsDualSense();
+	if(ds5_fix)
+		orientation_tracker.fuzz_enabled = false;
 	float accel_x, accel_y, accel_z, gyro_x, gyro_y, gyro_z;
 	switch(event.sensor)
 	{
@@ -615,19 +626,45 @@ inline bool Controller::HandleSensorEvent(SDL_ControllerSensorEvent event)
 			accel_x = event.data[0] / SDL_STANDARD_GRAVITY;
 			accel_y = event.data[1] / SDL_STANDARD_GRAVITY;
 			accel_z = event.data[2] / SDL_STANDARD_GRAVITY;
-			chiaki_accel_new_zero_set_active(&this->real_accel,
-			accel_x, accel_y, accel_z, true);
-			chiaki_orientation_tracker_update(
-				&orientation_tracker, state.gyro_x, state.gyro_y, state.gyro_z,
-				accel_x, accel_y, accel_z, &accel_zero, false, event.timestamp * 1000);
+			if(ds5_fix)
+			{
+				// v1.8.0: write raw accel to state, feed Madgwick with paired latest values, no accel_zero/fuzz
+				state.accel_x = accel_x;
+				state.accel_y = accel_y;
+				state.accel_z = accel_z;
+				chiaki_orientation_tracker_update(
+					&orientation_tracker, state.gyro_x, state.gyro_y, state.gyro_z,
+					state.accel_x, state.accel_y, state.accel_z, &accel_zero, true, event.timestamp * 1000);
+			}
+			else
+			{
+				chiaki_accel_new_zero_set_active(&this->real_accel,
+				accel_x, accel_y, accel_z, true);
+				chiaki_orientation_tracker_update(
+					&orientation_tracker, state.gyro_x, state.gyro_y, state.gyro_z,
+					accel_x, accel_y, accel_z, &accel_zero, false, event.timestamp * 1000);
+			}
 			break;
 		case SDL_SENSOR_GYRO:
 			gyro_x = event.data[0];
 			gyro_y = event.data[1];
 			gyro_z = event.data[2];
-			chiaki_orientation_tracker_update(
-				&orientation_tracker, gyro_x, gyro_y, gyro_z,
-				state.accel_x, state.accel_y, state.accel_z, &accel_zero, true, event.timestamp * 1000);
+			if(ds5_fix)
+			{
+				// v1.8.0: write raw gyro to state, feed Madgwick with paired latest values, no accel_zero/fuzz
+				state.gyro_x = gyro_x;
+				state.gyro_y = gyro_y;
+				state.gyro_z = gyro_z;
+				chiaki_orientation_tracker_update(
+					&orientation_tracker, state.gyro_x, state.gyro_y, state.gyro_z,
+					state.accel_x, state.accel_y, state.accel_z, &accel_zero, true, event.timestamp * 1000);
+			}
+			else
+			{
+				chiaki_orientation_tracker_update(
+					&orientation_tracker, gyro_x, gyro_y, gyro_z,
+					state.accel_x, state.accel_y, state.accel_z, &accel_zero, true, event.timestamp * 1000);
+			}
 			break;
 		default:
 			return false;
@@ -775,6 +812,19 @@ ChiakiControllerState Controller::GetState()
 	return state;
 }
 
+bool Controller::IsWired()
+{
+#ifdef CHIAKI_GUI_ENABLE_SDL_GAMECONTROLLER
+	if(!controller)
+		return false;
+	SDL_Joystick *joystick = SDL_GameControllerGetJoystick(controller);
+	if(!joystick)
+		return false;
+	return CHIAKI_SDL_JOYSTICK_GET_POWERLEVEL(joystick) == SDL_JOYSTICK_POWER_WIRED;
+#else
+	return false;
+#endif
+}
 void Controller::SetDualSenseRumble(uint8_t left, uint8_t right)
 {
 #ifdef CHIAKI_GUI_ENABLE_SDL_GAMECONTROLLER
@@ -784,7 +834,12 @@ void Controller::SetDualSenseRumble(uint8_t left, uint8_t right)
 		return;
 	DS5EffectsState_t state;
 	SDL_zero(state);
-	if(firmware_version < 0x0224)
+	// SDL_GameControllerGetFirmwareVersion() can return 0 on hotplug or with
+	// some USB/BT driver combinations. 0 is not a valid firmware version, so
+	// treat it as "new firmware" (>= 2.24). Otherwise we would send the legacy
+	// 0x01 enable bit, which current DualSense firmware ignores, causing rumble
+	// to silently disappear (e.g. when switching from Bluetooth to USB).
+	if(firmware_version != 0 && firmware_version < 0x0224)
 	{
 		state.ucEnableBits1 |= 0x01;
 		state.ucRumbleLeft = left >> 1;
@@ -940,6 +995,8 @@ void Controller::resetMotionControls()
 #ifdef CHIAKI_GUI_ENABLE_SDL_GAMECONTROLLER
 	if(!controller)
 		return;
+	if(manager->GetDS5GyroFixEnabled() && IsDualSense())
+		return; // v1.8.0 did not handle motion reset for SDL controllers
 	chiaki_accel_new_zero_set_active(&accel_zero, real_accel.accel_x, real_accel.accel_y, real_accel.accel_z, false);
 	chiaki_orientation_tracker_init(&orientation_tracker);
 	chiaki_orientation_tracker_update(

--- a/gui/src/qml/SettingsDialog.qml
+++ b/gui/src/qml/SettingsDialog.qml
@@ -2811,6 +2811,83 @@ DialogView {
                                 text: qsTr("(console setting)")
                             }
                         }
+                        RowLayout {
+                            spacing: 10
+                            Layout.alignment: Qt.AlignHCenter
+                            Label {
+                                Layout.alignment: Qt.AlignRight
+                                text: qsTr("DS5 Gyro Fix:")
+                            }
+
+                            C.CheckBox {
+                                id: ds5GyroFix
+                                text: qsTr("Write gyro/accel to controller state for native DualSense (restores v1.8.0 accuracy)")
+                                checked: Chiaki.settings.ds5GyroFix
+                                onToggled: Chiaki.settings.ds5GyroFix = checked
+                                KeyNavigation.priority: KeyNavigation.BeforeItem
+                                KeyNavigation.up: hapticOverride
+                            }
+
+                            Label {
+                                Layout.alignment: Qt.AlignRight
+                                text: qsTr("(Unchecked)")
+                            }
+                        }
+                        RowLayout {
+                            spacing: 10
+                            Layout.alignment: Qt.AlignHCenter
+                            Label {
+                                Layout.alignment: Qt.AlignRight
+                                text: qsTr("Haptics Anti-Latency:")
+                            }
+
+                            C.CheckBox {
+                                id: hapticsAntiLatency
+                                text: qsTr("Clear stale haptics queue when latency exceeds the configured threshold (prevents delayed/missing vibrations)")
+                                checked: Chiaki.settings.hapticsAntiLatency
+                                onToggled: Chiaki.settings.hapticsAntiLatency = checked
+                                KeyNavigation.priority: KeyNavigation.BeforeItem
+                                KeyNavigation.up: ds5GyroFix
+                            }
+
+                            Label {
+                                Layout.alignment: Qt.AlignRight
+                                text: qsTr("(Checked)")
+                            }
+                        }
+                        RowLayout {
+                            spacing: 10
+                            Layout.alignment: Qt.AlignHCenter
+                            Label {
+                                Layout.alignment: Qt.AlignRight
+                                text: qsTr("Queue Threshold:")
+                            }
+
+                            C.Slider {
+                                id: hapticsAntiLatencyMs
+                                Layout.preferredWidth: 250
+                                from: 20
+                                to: 100
+                                stepSize: 5
+                                value: Chiaki.settings.hapticsAntiLatencyMs
+                                onMoved: Chiaki.settings.hapticsAntiLatencyMs = value
+                                lastInFocusChain: true
+                                Label {
+                                    anchors {
+                                        left: parent.right
+                                        verticalCenter: parent.verticalCenter
+                                        leftMargin: 10
+                                    }
+                                    text: Math.round(parent.value) + qsTr(" ms")
+                                }
+                            }
+
+                            Label {
+                                Layout.alignment: Qt.AlignRight
+                                Layout.leftMargin: 250
+                                text: qsTr("(50 ms)")
+                            }
+                        }
                     }
                 }
             }

--- a/gui/src/qmlsettings.cpp
+++ b/gui/src/qmlsettings.cpp
@@ -133,6 +133,39 @@ void QmlSettings::setHapticOverride(float override)
     emit hapticOverrideChanged();
 }
 
+bool QmlSettings::ds5GyroFix() const
+{
+    return settings->GetDS5GyroFixEnabled();
+}
+
+void QmlSettings::setDS5GyroFix(bool enabled)
+{
+    settings->SetDS5GyroFixEnabled(enabled);
+    emit ds5GyroFixChanged();
+}
+
+bool QmlSettings::hapticsAntiLatency() const
+{
+    return settings->GetHapticsAntiLatencyEnabled();
+}
+
+void QmlSettings::setHapticsAntiLatency(bool enabled)
+{
+    settings->SetHapticsAntiLatencyEnabled(enabled);
+    emit hapticsAntiLatencyChanged();
+}
+
+int QmlSettings::hapticsAntiLatencyMs() const
+{
+    return settings->GetHapticsAntiLatencyMs();
+}
+
+void QmlSettings::setHapticsAntiLatencyMs(int ms)
+{
+    settings->SetHapticsAntiLatencyMs(ms);
+    emit hapticsAntiLatencyMsChanged();
+}
+
 int QmlSettings::audioVideoDisabled() const
 {
     return static_cast<int>(settings->GetAudioVideoDisabled());
@@ -1879,6 +1912,9 @@ void QmlSettings::refreshAllKeys()
     emit logSanitizeChanged();
     emit vSyncEnabledChanged();
     emit hapticOverrideChanged();
+    emit ds5GyroFixChanged();
+    emit hapticsAntiLatencyChanged();
+    emit hapticsAntiLatencyMsChanged();
     emit rumbleHapticsIntensityChanged();
     emit buttonsByPositionChanged();
     emit allowJoystickBackgroundEventsChanged();

--- a/gui/src/streamsession.cpp
+++ b/gui/src/streamsession.cpp
@@ -307,6 +307,8 @@ StreamSessionConnectInfo::StreamSessionConnectInfo(
 	this->enable_dualsense = true;
 	this->enable_idr_on_fec_failure = settings->GetIDROnFECFailureEnabled();
 	this->rumble_haptics_intensity = settings->GetRumbleHapticsIntensity();
+	this->haptics_anti_latency = settings->GetHapticsAntiLatencyEnabled();
+	this->haptics_anti_latency_ms = settings->GetHapticsAntiLatencyMs();
 	this->buttons_by_pos = settings->GetButtonsByPosition();
 	this->start_mic_unmuted = settings->GetStartMicUnmuted();
 	this->port_guessing_enabled = settings->GetPortGuessingEnabled();
@@ -384,7 +386,8 @@ StreamSession::StreamSession(const StreamSessionConnectInfo &connect_info, QObje
 	ps5_rumble_intensity(0x00),
 	ps5_trigger_intensity(0x00),
 	rumble_haptics_connected(false),
-	rumble_haptics_on(false)
+	rumble_haptics_on(false),
+	rumble_haptics_baseline(0.0f)
 {
 	mic_buf.buf = nullptr;
 	connected = false;
@@ -483,6 +486,8 @@ StreamSession::StreamSession(const StreamSessionConnectInfo &connect_info, QObje
 	dpad_touch_shortcut3 = connect_info.dpad_touch_shortcut3;
 	dpad_touch_shortcut4 = connect_info.dpad_touch_shortcut4;
 	haptic_override = connect_info.haptic_override;
+	haptics_anti_latency = connect_info.haptics_anti_latency;
+	haptics_anti_latency_ms = connect_info.haptics_anti_latency_ms;
 #if CHIAKI_LIB_ENABLE_PI_DECODER
 	if(connect_info.decoder == Decoder::Pi && chiaki_connect_info.video_profile.codec != CHIAKI_CODEC_H264)
 	{
@@ -594,6 +599,7 @@ StreamSession::StreamSession(const StreamSessionConnectInfo &connect_info, QObje
 	connect(this, &StreamSession::DualSenseIntensityChanged, ControllerManager::GetInstance(), &ControllerManager::SetDualSenseIntensity);
 	if(connect_info.buttons_by_pos)
 		ControllerManager::GetInstance()->SetButtonsByPos();
+	ControllerManager::GetInstance()->SetDS5GyroFixEnabled(connect_info.settings->GetDS5GyroFixEnabled());
 #endif
 #if CHIAKI_GUI_ENABLE_SETSU
 	setsu_motion_device = nullptr;
@@ -1764,6 +1770,7 @@ void StreamSession::ConnectRumbleHaptics()
 		return;
 	rumble_haptics = {};
 	rumble_haptics.reserve(20);
+	rumble_haptics_baseline = 0.0f;
 	connect(this, &StreamSession::RumbleHapticPushed, this, &StreamSession::QueueRumbleHaptics);
 	auto rumble_haptics_interval = RUMBLE_HAPTICS_PACKETS_PER_RUMBLE * 10;
 	auto rumble_haptics_timer = new QTimer(this);
@@ -2197,8 +2204,48 @@ void StreamSession::PushHapticsFrame(uint8_t *buf, size_t buf_size)
 		return;
 	}
 #endif
+	// If a wired DualSense is connected but the dedicated haptic audio device
+	// failed to open (session started over Bluetooth, audio device not yet
+	// enumerated after a USB/BT hot-swap, transient open failure, ...), retry
+	// opening it so the stream uses the real HD haptics instead of the rumble
+	// fallback. Rate-limited to avoid spamming SDL on every frame; Bluetooth
+	// controllers report a battery level (not WIRED) and are skipped, so they
+	// keep using the rumble fallback below.
+	if(haptics_output == 0)
+	{
+		bool wired_dualsense = false;
+		for(auto controller : controllers)
+		{
+			if((controller->IsDualSense() || controller->IsDualSenseEdge()) && controller->IsWired())
+			{
+				wired_dualsense = true;
+				break;
+			}
+		}
+		if(wired_dualsense && (chiaki_time_now_monotonic_ms() - haptics_retry_timestamp_ms >= 2000))
+		{
+			haptics_retry_timestamp_ms = chiaki_time_now_monotonic_ms();
+			QMetaObject::invokeMethod(this, [this]() { ConnectHaptics(); }, Qt::QueuedConnection);
+		}
+	}
 	if((rumble_haptics_intensity != RumbleHapticsIntensity::Off) && haptics_output == 0)
 	{
+		// When the DualSense haptic audio device is unavailable (typical over
+		// Bluetooth on Windows, see "could not find the DualSense audio device"),
+		// the streaming haptic audio cannot be played via the dedicated HD
+		// haptics and is instead routed here and converted into rumble-motor
+		// strength. The raw engine/road low-frequency content then feels like
+		// excessive, continuous rumble (e.g. GT7 vibrating on a flat road).
+		// Detect this case and attenuate so it doesn't feel overwhelming.
+		bool dualsense_haptic_fallback = false;
+		for(auto controller : controllers)
+		{
+			if(controller->IsDualSense() || controller->IsDualSenseEdge())
+			{
+				dualsense_haptic_fallback = true;
+				break;
+			}
+		}
 		int16_t amplitudel = 0, amplituder = 0;
 		uint32_t suml = 0, sumr = 0;
 		const size_t sample_size = 2 * sizeof(int16_t); // stereo samples
@@ -2221,6 +2268,45 @@ void StreamSession::PushHapticsFrame(uint8_t *buf, size_t buf_size)
 		temp_right = (temp_right > HAPTIC_RUMBLE_MIN_STRENGTH) ? temp_right : 0;
 		if(temp_left == 0 && temp_right == 0)
 			return;
+		if(dualsense_haptic_fallback)
+		{
+			// DualSense haptic audio fallback: the streaming audio is being
+			// dumped into the rumble motors. Games like GT7 constantly send a
+			// low-frequency engine/road texture stream even on a flat road,
+			// which would otherwise feel like continuous, overwhelming rumble
+			// (the exact complaint when connecting over Bluetooth, where the
+			// dedicated haptic audio device is unavailable). Apply an adaptive
+			// noise gate: track the recent steady-state strength and only
+			// convert the *excess* above that baseline to rumble, so constant
+			// surfaces stay quiet while impacts/curbs/transients still rumble.
+			uint32_t raw = (temp_left > temp_right) ? temp_left : temp_right;
+			float delta = static_cast<float>(raw) - rumble_haptics_baseline;
+			if(delta > rumble_haptics_baseline * 0.5f + HAPTIC_RUMBLE_MIN_STRENGTH)
+			{
+				// Significant rise over the steady-state level: emit only the
+				// excess, and let the baseline slowly chase so sustained loud
+				// content eventually fades instead of burning the motors.
+				if(temp_left > rumble_haptics_baseline)
+					temp_left -= static_cast<uint32_t>(rumble_haptics_baseline);
+				else
+					temp_left = 0;
+				if(temp_right > rumble_haptics_baseline)
+					temp_right -= static_cast<uint32_t>(rumble_haptics_baseline);
+				else
+					temp_right = 0;
+				rumble_haptics_baseline = rumble_haptics_baseline + delta * 0.1f;
+			}
+			else
+			{
+				// Steady-state content (flat road, engine hum): suppress it
+				// and let the baseline track the current level.
+				temp_left = 0;
+				temp_right = 0;
+				rumble_haptics_baseline = rumble_haptics_baseline * 0.9f + raw * 0.1f;
+			}
+			if(temp_left == 0 && temp_right == 0)
+				return;
+		}
 		switch(rumble_haptics_intensity)
 		{
 			case RumbleHapticsIntensity::VeryWeak:
@@ -2251,6 +2337,16 @@ void StreamSession::PushHapticsFrame(uint8_t *buf, size_t buf_size)
 				left = temp_left;
 				right = temp_right;
 				break;
+		}
+		// DualSense haptic audio fallback: the adaptive noise gate above has
+		// already stripped the constant road/engine content, so the remaining
+		// signal is made of real events only. A mild attenuation (0.8) is kept
+		// since actuator-level audio still feels stronger once mapped to the
+		// rumble motors, but the gate no longer needs heavy damping.
+		if(dualsense_haptic_fallback)
+		{
+			left = static_cast<uint16_t>(left * 0.8f);
+			right = static_cast<uint16_t>(right * 0.8f);
 		}
 		// Set minimum rumble value if above rumble min for controllers that shift up to 9 bits when rumbling
 		left = ((left > 0 && left < (1 << 9)) ? (1 << 9) : left);
@@ -2315,6 +2411,22 @@ void StreamSession::PushHapticsFrame(uint8_t *buf, size_t buf_size)
 	{
 		CHIAKI_LOGE(log.GetChiakiLog(), "Failed to resample haptics audio: %s", SDL_GetError());
 		return;
+	}
+
+	// Prevent haptics latency buildup: if queued audio exceeds threshold,
+	// drain stale frames so current vibration plays immediately instead of
+	// waiting behind a backlog caused by network jitter.
+	if(haptics_anti_latency)
+	{
+		// 4 channels * 2 bytes (S16) per sample; haptics_buffer_size is samples (10ms)
+		const size_t bytes_per_buffer = haptics_buffer_size * 4 * 2;
+		const size_t threshold = bytes_per_buffer * haptics_anti_latency_ms / 10;
+		if(SDL_GetQueuedAudioSize(haptics_output) > threshold)
+		{
+			CHIAKI_LOGV(log.GetChiakiLog(), "Haptics queue exceeded %zu bytes (%zu ms), clearing stale frames",
+					threshold, threshold / bytes_per_buffer * 10);
+			SDL_ClearQueuedAudio(haptics_output);
+		}
 	}
 
 	if (SDL_QueueAudio(haptics_output, cvt.buf, cvt.len_cvt) < 0)

--- a/lib/include/chiaki/orientation.h
+++ b/lib/include/chiaki/orientation.h
@@ -27,7 +27,7 @@ typedef struct chiaki_accel_new_zero
 
 CHIAKI_EXPORT void chiaki_orientation_init(ChiakiOrientation *orient);
 CHIAKI_EXPORT void chiaki_orientation_update(ChiakiOrientation *orient,
-		float gx, float gy, float gz, float ax, float ay, float az, float beta, float time_step_sec);
+		float gx, float gy, float gz, float ax, float ay, float az, float beta, float time_step_sec, bool fuzz_enabled);
 
 /**
  * Extension of ChiakiOrientation, also tracking an absolute timestamp and the current gyro/accel state
@@ -39,6 +39,7 @@ typedef struct chiaki_orientation_tracker_t
 	ChiakiOrientation orient;
 	uint32_t timestamp;
 	uint64_t sample_index;
+	bool fuzz_enabled;
 } ChiakiOrientationTracker;
 
 CHIAKI_EXPORT void chiaki_orientation_tracker_init(ChiakiOrientationTracker *tracker);

--- a/lib/src/orientation.c
+++ b/lib/src/orientation.c
@@ -29,7 +29,7 @@ static float inv_sqrt(float x);
 static void fuzz(const float cur, float *prev, const float fuzz, const float wprev, const float wprev2x);
 
 CHIAKI_EXPORT void chiaki_orientation_update(ChiakiOrientation *orient,
-		float gx, float gy, float gz, float ax, float ay, float az, float beta, float time_step_sec)
+		float gx, float gy, float gz, float ax, float ay, float az, float beta, float time_step_sec, bool fuzz_enabled)
 {
 	float q0 = orient->w, q1 = orient->x, q2 = orient->y, q3 = orient->z;
 	// Madgwick's IMU algorithm.
@@ -105,10 +105,20 @@ CHIAKI_EXPORT void chiaki_orientation_update(ChiakiOrientation *orient,
 	q2 *= recip_norm;
 	q3 *= recip_norm;
 
-	fuzz(q0, &orient->w, ORIENT_FUZZ, FUZZ_FILTER_PREV_WEIGHT, FUZZ_FILTER_PREV_WEIGHT2x);
-	fuzz(q1, &orient->x, ORIENT_FUZZ, FUZZ_FILTER_PREV_WEIGHT, FUZZ_FILTER_PREV_WEIGHT2x);
-	fuzz(q2, &orient->y, ORIENT_FUZZ, FUZZ_FILTER_PREV_WEIGHT, FUZZ_FILTER_PREV_WEIGHT2x);
-	fuzz(q3, &orient->z, ORIENT_FUZZ, FUZZ_FILTER_PREV_WEIGHT, FUZZ_FILTER_PREV_WEIGHT2x);
+	if(fuzz_enabled)
+	{
+		fuzz(q0, &orient->w, ORIENT_FUZZ, FUZZ_FILTER_PREV_WEIGHT, FUZZ_FILTER_PREV_WEIGHT2x);
+		fuzz(q1, &orient->x, ORIENT_FUZZ, FUZZ_FILTER_PREV_WEIGHT, FUZZ_FILTER_PREV_WEIGHT2x);
+		fuzz(q2, &orient->y, ORIENT_FUZZ, FUZZ_FILTER_PREV_WEIGHT, FUZZ_FILTER_PREV_WEIGHT2x);
+		fuzz(q3, &orient->z, ORIENT_FUZZ, FUZZ_FILTER_PREV_WEIGHT, FUZZ_FILTER_PREV_WEIGHT2x);
+	}
+	else
+	{
+		orient->w = q0;
+		orient->x = q1;
+		orient->y = q2;
+		orient->z = q3;
+	}
 }
 
 // input fuzz filter like the one used in kernel input system
@@ -157,6 +167,7 @@ CHIAKI_EXPORT void chiaki_orientation_tracker_init(ChiakiOrientationTracker *tra
 	chiaki_orientation_init(&tracker->orient);
 	tracker->timestamp = 0;
 	tracker->sample_index = 0;
+	tracker->fuzz_enabled = true;
 }
 
 CHIAKI_EXPORT void chiaki_orientation_tracker_update(ChiakiOrientationTracker *tracker,
@@ -188,7 +199,7 @@ CHIAKI_EXPORT void chiaki_orientation_tracker_update(ChiakiOrientationTracker *t
 	tracker->timestamp = timestamp_us;
 	chiaki_orientation_update(&tracker->orient, gx, gy, gz, ax, ay, az,
 			tracker->sample_index < WARMUP_SAMPLES_COUNT ? BETA_WARMUP : BETA_DEFAULT,
-			(float)delta_us / 1000000.0f);
+			(float)delta_us / 1000000.0f, tracker->fuzz_enabled);
 }
 
 CHIAKI_EXPORT void chiaki_orientation_tracker_apply_to_controller_state(ChiakiOrientationTracker *tracker,


### PR DESCRIPTION
Restore native DualSense gyro/accel accuracy to v1.8.0 via a configurable ds5_gyro_fix path: write raw accel/gyro to controller state, feed Madgwick with paired latest values, skip accel_zero de-bias and fuzz smoothing. Add fuzz_enabled flag to ChiakiOrientationTracker/chiaki_orientation_update; non-DualSense paths unchanged.

Haptics anti-latency: add toggle (default on) and a configurable 20-100ms threshold that clears the stale SDL haptic queue when the backlog exceeds it, so current vibration plays immediately instead of behind network-jitter backlog.

Auto-reopen the wired DualSense haptics audio device when it failed to open at start or was lost on a USB/BT hot-swap; add Controller::IsWired() from the SDL power level to limit retries to wired controllers.

Bluetooth: soften the rumble fallback event decay and suppress the persistent false rumble on flat road in GT7.