### PR TITLE
Add web bridge: browser Remote Play over WebRTC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ chiaki.conf
 .cache/
 *.vscode
 site/
+.env

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(CHIAKI_ENABLE_CLI "Enable CLI for Chiaki" ON)
 option(CHIAKI_ENABLE_GUI "Enable Qt GUI" ON)
 option(CHIAKI_ENABLE_ANDROID "Enable Android (Use only as part of the Gradle Project)" OFF)
 option(CHIAKI_ENABLE_BOREALIS "Enable Borealis GUI (For Nintendo Switch or PC)" OFF)
+option(CHIAKI_ENABLE_WEBBRIDGE "Enable web bridge (browser client over WebRTC)" OFF)
 tri_option(CHIAKI_ENABLE_SETSU "Enable libsetsu for touchpad input from controller" AUTO)
 tri_option(CHIAKI_ENABLE_STEAMDECK_NATIVE "Enable sdeck for native gyro and haptic feedback from Steam Deck" ON)
 option(CHIAKI_LIB_ENABLE_OPUS "Use Opus as part of Chiaki Lib" ON)
@@ -276,6 +277,10 @@ endif()
 
 if(CHIAKI_ENABLE_GUI)
 	add_subdirectory(gui)
+endif()
+
+if(CHIAKI_ENABLE_WEBBRIDGE)
+	add_subdirectory(webbridge)
 endif()
 
 if(CHIAKI_ENABLE_TESTS)

--- a/webbridge/.env.example
+++ b/webbridge/.env.example
@@ -1,0 +1,39 @@
+# chiaki-web bridge environment — copy to `.env` and fill in.
+# The bridge loads `.env` from its working directory at startup. `.env` itself
+# is gitignored; never commit real credentials.
+
+# Default PSN Account ID (base64 of 8 bytes) used for pairing when a register
+# request doesn't carry one and none is stored in config.json. Optional — you
+# can also enter it in the web UI at registration time.
+CHIAKI_PSN_ACCOUNT_ID=
+
+# Optional shared-secret gate. When set, everything that touches the console
+# (/api/hosts|wakeup|register|config and the `start` signaling message)
+# requires this token (X-Auth-Token header / token field). Defense in depth —
+# put a real auth gate in front for production.
+CHIAKI_WEB_TOKEN=
+
+# Cloudflare TURN ("Realtime" / streaming app): the bridge mints short-lived
+# ICE credentials per session and shares them with the browser over signaling.
+# Leave blank for LAN-only use (host candidates + public STUN).
+CHIAKI_TURN_KEY_ID=
+CHIAKI_TURN_API_TOKEN=
+
+# Force all WebRTC media onto the TURN relay. Needed when the bridge is behind
+# a NAT/firewall where direct/srflx ICE pairs half-open and DTLS never
+# completes for remote users. Requires the TURN credentials above.
+#CHIAKI_FORCE_RELAY=1
+
+# Direct P2P tuning (alternative to relay): pin all WebRTC/ICE UDP to one port
+# so it can be port-forwarded on the router, and bind to the matching LAN IP.
+#CHIAKI_ICE_PORT=
+#CHIAKI_BIND_ADDR=
+
+# Cap MTU so the DTLS handshake survives a low-MTU direct path (ICE succeeds
+# but DTLS stalls otherwise).
+#CHIAKI_MTU=
+
+# The ICE backend (libjuice vs. libnice) is compiled into libdatachannel, so
+# it's selected by which libdatachannel.so the loader picks, not by an env var
+# here. TURN-relayed remote clients need a libnice build — see the "ICE
+# backend" section of README.md.

--- a/webbridge/CMakeLists.txt
+++ b/webbridge/CMakeLists.txt
@@ -1,0 +1,67 @@
+# chiaki-web bridge: headless frontend relaying sessions to browsers over WebRTC
+
+find_package(LibDataChannel QUIET)
+if(NOT LibDataChannel_FOUND)
+	find_library(DATACHANNEL_LIB datachannel REQUIRED)
+	add_library(LibDataChannel::LibDataChannel SHARED IMPORTED)
+	set_target_properties(LibDataChannel::LibDataChannel PROPERTIES IMPORTED_LOCATION "${DATACHANNEL_LIB}")
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(OPUS_PC REQUIRED IMPORTED_TARGET opus)
+
+# Header-only dependencies, fetched and pinned at configure time rather than
+# vendored into the tree:
+#   nlohmann/json — ergonomic JSON for the REST + signaling layer
+#   cpp-httplib   — HTTP server (static frontend + REST) and the HTTPS client
+#                   used to mint short-lived Cloudflare TURN credentials
+include(FetchContent)
+
+set(JSON_Install OFF CACHE INTERNAL "")
+FetchContent_Declare(nlohmann_json
+	GIT_REPOSITORY https://github.com/nlohmann/json.git
+	GIT_TAG v3.11.3
+	GIT_SHALLOW ON)
+
+# HTTPS is required for the TURN credential-minting client; fail loudly if the
+# TLS backend is missing rather than silently dropping to http-only.
+set(HTTPLIB_REQUIRE_OPENSSL ON CACHE INTERNAL "")
+set(HTTPLIB_INSTALL OFF CACHE INTERNAL "")
+FetchContent_Declare(cpp-httplib
+	GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+	GIT_TAG v0.18.3
+	GIT_SHALLOW ON)
+
+FetchContent_MakeAvailable(nlohmann_json cpp-httplib)
+
+add_executable(chiaki-webbridge
+	src/main.cpp
+	src/config.cpp
+	src/chiakisource.cpp
+	src/demosource.cpp
+	src/relay.cpp
+	src/wstransport.cpp
+	src/discoverymgr.cpp
+	src/registration.cpp
+	src/server.cpp)
+
+set_target_properties(chiaki-webbridge PROPERTIES
+	CXX_STANDARD 17
+	CXX_STANDARD_REQUIRED ON)
+
+# httplib::httplib carries CPPHTTPLIB_OPENSSL_SUPPORT and links OpenSSL
+# transitively (HTTPLIB_REQUIRE_OPENSSL above).
+target_link_libraries(chiaki-webbridge
+	chiaki-lib
+	LibDataChannel::LibDataChannel
+	PkgConfig::OPUS_PC
+	nlohmann_json::nlohmann_json
+	httplib::httplib
+	Threads::Threads)
+
+# Default frontend location next to the binary for `ninja && run` workflows.
+# Symlink (not copy) so edits to the frontend sources are always live.
+add_custom_command(TARGET chiaki-webbridge POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E rm -rf "$<TARGET_FILE_DIR:chiaki-webbridge>/frontend"
+	COMMAND ${CMAKE_COMMAND} -E create_symlink
+	"${CMAKE_CURRENT_SOURCE_DIR}/frontend" "$<TARGET_FILE_DIR:chiaki-webbridge>/frontend")

--- a/webbridge/PROTOCOL.md
+++ b/webbridge/PROTOCOL.md
@@ -1,0 +1,160 @@
+# chiaki-web bridge — wire protocol
+
+Contract between the bridge backend (`webbridge/src`) and the web frontend
+(`webbridge/frontend`). Architecture modeled on moonlight-web: video as
+Annex-B access units over a partially-reliable DataChannel decoded with
+WebCodecs, audio as a native RTP Opus track, input as JSON over a reliable
+DataChannel.
+
+## Ports
+
+- HTTP (static frontend + REST): default `9080`
+- Signaling WebSocket: default `9081` (any path accepted)
+
+The frontend discovers the WS port via `GET /api/info`. When accessed through
+a path-preserving reverse proxy (e.g. `https://<host>/lp/9080/`), the frontend
+must build the WS URL by substituting the port segment in its own URL
+(`/lp/9081/`) rather than using `location.port`.
+
+## REST API (HTTP port)
+
+- `GET /api/info` → `{ "name", "version", "wsPort": 9081 }`
+- `GET /api/hosts` → `[ { "host", "nickname", "mac", "ps5": bool,
+  "state": "ready"|"standby"|"unknown", "discovered": bool,
+  "registered": bool, "appName": string|null } ]`
+  (union of discovery results and registered consoles from config)
+- `POST /api/wakeup` `{ "host" }` → `204` (console must be registered)
+- `POST /api/register` `{ "host", "ps5": bool, "pin": number,
+  "psnAccountId": base64 string }` → `200 { "nickname" }` on success,
+  `4xx/5xx { "error" }` on failure. Blocking (runs chiaki_regist).
+- `GET /api/config` → sanitized config (no keys), includes
+  `{ "psnAccountIdSet": bool, "consoles": [...] }`
+
+## Signaling (WebSocket, JSON text messages)
+
+Client connects, then:
+
+1. client → `{ "type": "start", "host": "<ip>" }` or
+   `{ "type": "start", "demo": true }`, optional fields:
+   `"resolution": "360p"|"540p"|"720p"|"1080p"`, `"fps": 30|60`,
+   `"codec": "h264"|"hevc"`, `"bitrate": number (kbps, 0 = preset)`,
+   `"transport": "webrtc"|"ws"` (default webrtc)
+2. bridge → `{ "type": "iceServers", "iceServers": [RTCIceServer...] }`
+   (webrtc only, only when TURN is configured — short-lived credentials
+   minted from Cloudflare TURN via CHIAKI_TURN_KEY_ID/CHIAKI_TURN_API_TOKEN;
+   sent before the offer so the browser can construct its pc with them)
+3. bridge → `{ "type": "streamInfo", "codec": "h264"|"hevc",
+   "width", "height", "fps" }`
+4. bridge → `{ "type": "offer", "sdp" }` (webrtc only; bridge is always the
+   offerer; all media/channels are in this offer)
+5. client → `{ "type": "answer", "sdp" }` (webrtc only)
+6. both → `{ "type": "candidate", "candidate", "mid" }` (trickle ICE, webrtc)
+7. bridge → `{ "type": "status", "state": "connecting"|"connected" }`,
+   `{ "type": "quit", "reason", "error": bool }`
+8. client → `{ "type": "stop" }` ends the session.
+9. client → `{ "type": "switchTransport", "transport": "ws" }` swaps the
+   media path mid-session WITHOUT restarting the console session (used by
+   the frontend's automatic WebRTC→WebSocket fallback; the console holds
+   its Remote Play slot for ~25 s after a disconnect, so a full restart
+   would be painful). The bridge answers with `audioInfo` +
+   `status: connected` and internally requests an IDR (with SPS/PPS
+   prepended) so the fresh decoder can sync. Transport-level frameIds
+   restart at 0 — the client must reset its reassembler.
+
+Only one streaming client at a time; a second `start` gets
+`{ "type": "quit", "reason": "busy", "error": true }`.
+
+## PeerConnection layout
+
+Order in SDP (bridge side): audio track added BEFORE DataChannels are created
+(libdatachannel publishes the offer on the first `createDataChannel`).
+
+- **Audio**: RTP Opus track, sendonly, payload type 111,
+  `minptime=10;useinbandfec=1;stereo=1;sprop-stereo=1`, SSRC declared in the
+  description. 48 kHz stereo. Browser plays it via an `<audio>`/`AudioContext`
+  attached to the received MediaStreamTrack — the browser's jitter buffer,
+  FEC and PLC do the work.
+- **DataChannel "video"**: `negotiated: true, id: 0, ordered: true,
+  maxRetransmits: 3`. Binary. Carries fragmented video frames (below).
+- **DataChannel "input"**: `negotiated: true, id: 2` (defaults: reliable,
+  ordered). JSON text, bidirectional.
+- **DataChannel "mic"** (browser → bridge): `negotiated: true, id: 4,
+  ordered: false, maxRetransmits: 0`. Binary: raw 48 kHz mono s16le PCM,
+  ideally 480-sample (960-byte) chunks; the bridge re-frames and feeds
+  libchiaki's Opus encoder (which produces the exact 40-byte CBR frames the
+  console requires). Enable/disable via `{"t":"micOn"}` / `{"t":"micOff"}`
+  on the input DC — the bridge sends `connect_microphone` on first enable
+  and mute/unmute toggles after.
+
+The frontend must create the same negotiated channels with identical ids and
+reliability settings.
+
+## WebSocket transport (`"transport": "ws"`)
+
+Fallback for UDP-hostile networks: no PeerConnection at all — media and input
+are multiplexed over the signaling WebSocket (plain TCP, traverses whatever
+proxy/tunnel served the page). Binary WS messages carry a 1-byte channel
+prefix:
+
+| chan | direction        | payload |
+|------|------------------|---------|
+| 0x01 | bridge → browser | video: 17-byte fragment header (identical format to the video DC, always `totalChunks=1`) + complete Annex-B AU |
+| 0x02 | bridge → browser | audio: interleaved s16le PCM — the bridge decodes the console's Opus (no RTP jitter buffer to lean on; the browser plays it via an AudioWorklet with its own jitter buffer) |
+| 0x03 | browser → bridge | mic: 48 kHz mono s16le PCM chunks (same payload as the mic DC) |
+
+Audio format is announced via `{ "type": "audioInfo", "rate", "channels" }`.
+Input/event JSON rides the same socket as text; `"t"`-keyed input messages
+and `"type"`-keyed signaling share it without collision. The bridge applies
+TCP backpressure policy: past ~1 MiB of send backlog delta frames are dropped
+(an IDR is requested on drain), stale audio is dropped earlier, and only a
+saturated socket (8 MiB) drops keyframes.
+
+## Video fragment format (DC "video", binary, big-endian)
+
+17-byte header per fragment, then payload:
+
+| off | size | field |
+|-----|------|-------|
+| 0   | u32  | frameId (monotonic, wraps) |
+| 4   | u16  | chunkIndex |
+| 6   | u16  | totalChunks |
+| 8   | u8   | flags: bit0 = keyframe (IDR or contains SPS/PPS/VPS) |
+| 9   | u32  | payloadSize (bytes of payload in THIS fragment) |
+| 13  | u32  | backendTs (ms, monotonic clock at send time; same for all chunks of a frame) |
+
+Chunk payload cap: 16000 bytes. Reassembled payload = one complete Annex-B
+access unit (start codes `00 00 00 01`/`00 00 01`). The first video frame(s)
+carry codec parameter sets (SPS/PPS, +VPS for HEVC) — parameter sets may also
+arrive as a standalone AU when the stream reconfigures; frontend feeds
+everything to VideoDecoder in Annex-B form.
+
+Loss handling: if the frontend observes a frameId gap or a decode error, it
+sends `{ "t": "idr" }` on the input DC; the bridge answers by failing the next
+video sample callback once, which makes the console send a recovery keyframe.
+
+## Input DC messages
+
+Browser → bridge:
+
+- Controller state (send at input-poll rate; bridge paces the wire):
+  `{ "t": "cs", "b": u32, "l2": 0-255, "r2": 0-255,
+     "lx": i16, "ly": i16, "rx": i16, "ry": i16,
+     "tp": [[id, x, y], ...] }`
+  `tp` optional, up to 2 touches on the 1920×942 touchpad plane.
+  `b` is the chiaki button bitmask:
+  CROSS 1<<0, MOON(circle) 1<<1, BOX(square) 1<<2, PYRAMID(triangle) 1<<3,
+  DPAD_LEFT 1<<4, DPAD_RIGHT 1<<5, DPAD_UP 1<<6, DPAD_DOWN 1<<7,
+  L1 1<<8, R1 1<<9, L3 1<<10, R3 1<<11, OPTIONS 1<<12, SHARE 1<<13,
+  TOUCHPAD 1<<14, PS 1<<15. (L2/R2 are the analog fields.)
+- Motion (optional): `{ "t": "mo", "gx","gy","gz","ax","ay","az",
+  "ox","oy","oz","ow" }` (gyro rad/s, accel g, orientation quaternion)
+- `{ "t": "idr" }` — request recovery keyframe
+- `{ "t": "pin", "pin": "1234" }` — login PIN reply
+
+Bridge → browser:
+
+- `{ "t": "rumble", "l": 0-255, "r": 0-255 }`
+- `{ "t": "led", "r", "g", "b" }`
+- `{ "t": "pinRequest", "incorrect": bool }` — show PIN dialog
+- `{ "t": "nickname", "name" }`
+- `{ "t": "stats", ... }` (periodic, informational)

--- a/webbridge/README.md
+++ b/webbridge/README.md
@@ -1,0 +1,117 @@
+# chiaki-web
+
+Play PlayStation Remote Play in any modern browser (desktop or mobile).
+
+A small headless bridge embeds libchiaki and runs the actual Remote Play
+session; the browser is a thin client. Architecture modeled on
+[moonlight-web](https://github.com/linckosz/moonlight-web):
+
+- **Video**: complete Annex-B H.264/HEVC access units from libchiaki's video
+  callback, fragmented over a partially-reliable WebRTC DataChannel
+  (ordered, 3 retransmits), decoded in the browser with **WebCodecs** in a
+  worker, rendered to an OffscreenCanvas.
+- **Audio**: the Opus frames from libchiaki's audio sink are sent as a native
+  **RTP Opus track** on the same PeerConnection — the browser's jitter
+  buffer, in-band FEC and packet-loss concealment handle the lossy path.
+- **Input**: JSON over a reliable DataChannel; keyboard, mouse→touchpad,
+  Gamepad API (with rumble), and a multi-touch on-screen controller on
+  mobile. The bridge feeds `ChiakiControllerState`; libchiaki paces the wire.
+- **Everything else** (discovery, wakeup, pairing/registration) is REST.
+
+See `PROTOCOL.md` for the exact wire contract.
+
+## Build
+
+Requires: system libdatachannel, opus, plus chiaki-ng's usual lib deps
+(openssl, curl≥8.11 with WebSocket, json-c, miniupnpc, libevent, protoc +
+python-protobuf for nanopb). Two header-only deps — nlohmann/json and
+cpp-httplib — are fetched and pinned at configure time via CMake
+`FetchContent` (network access needed on first configure), not vendored.
+
+```
+cmake -B build -G Ninja \
+    -DCHIAKI_ENABLE_WEBBRIDGE=ON \
+    -DCHIAKI_ENABLE_GUI=OFF -DCHIAKI_ENABLE_CLI=OFF -DCHIAKI_ENABLE_TESTS=OFF \
+    -DCHIAKI_USE_SYSTEM_CURL=ON
+ninja -C build chiaki-webbridge
+```
+
+## Run
+
+```
+./build/webbridge/chiaki-webbridge
+```
+
+Then open `http://<bridge-host>:9080/`. Options: `--http-port`, `--ws-port`,
+`--bind`, `--frontend <dir>`, `--config <file>`, `--verbose`.
+
+First-time setup, all from the web UI:
+
+1. Put the console into pairing mode (Settings → Remote Play → Link Device).
+2. "Register" on the console card: enter the PIN and your PSN Account ID
+   (base64, same value the chiaki-ng GUI uses).
+3. Connect.
+
+Config (registration keys) is stored in `~/.config/chiaki-web/config.json`.
+
+**Demo mode**: the "Demo" button streams an ffmpeg test pattern + Opus test
+tone through the full pipeline without a console — useful to validate a
+browser/network before touching real hardware.
+
+## Exposing publicly (Cloudflare Tunnel)
+
+The bridge serves HTTP on one port and the signaling WebSocket on another;
+for a single public hostname, route the `/ws` path to the WS port (the
+frontend automatically uses same-origin `/ws` when served on standard
+ports). Example cloudflared ingress:
+
+```yaml
+ingress:
+  - hostname: playstation.example.com
+    path: ^/ws.*
+    service: http://localhost:9081
+  - hostname: playstation.example.com
+    service: http://localhost:9080
+  - service: http_status:404
+```
+
+Copy `.env.example` to `.env` (in the bridge's working directory) to configure
+optional credentials — PSN account ID, an access token, and Cloudflare TURN
+keys. `.env` is gitignored; keep real secrets out of the tree.
+
+Set `CHIAKI_WEB_TOKEN=<secret>` in `.env` to require an access token for
+everything that touches the console (`/api/hosts|wakeup|register|config` via
+`X-Auth-Token`, and the `start` signaling message). The frontend prompts for
+it once and stores it in localStorage. This is defense in depth — put a real
+auth gate (e.g. Cloudflare Access) in front for production use. Note that
+WebRTC media does not traverse the tunnel: the browser connects to the
+bridge host directly (LAN or STUN-friendly NAT; no TURN yet).
+
+## ICE backend (advanced: TURN-relayed remote clients)
+
+The ICE engine is compiled into `libdatachannel`, so the bridge uses whichever
+`libdatachannel.so` the dynamic linker loads — no bridge-side option selects
+it. The default system build uses **libjuice**, which is fine for LAN and
+STUN-friendly NAT.
+
+Relay-only clients (UDP-restricted networks, forced-TURN) need a
+**libnice**-backed `libdatachannel`: the libjuice build mishandles
+TURN-relayed connectivity checks (rejects relayed binding requests with 400).
+If you have such a build, select it with the standard loader mechanism — no
+wrapper script required:
+
+```
+LD_LIBRARY_PATH=/path/to/libnice-datachannel/lib ./chiaki-webbridge
+```
+
+## Status / limitations
+
+- LAN-focused: ICE uses host candidates + public STUN. No TURN, no built-in
+  remote access — front it with your own reverse proxy/VPN for now (the
+  signaling and media are standard WebRTC, so a TURN server drops in).
+- PSN remote connection (holepunch) path not wired up yet.
+- One streaming client at a time.
+- Motion, adaptive triggers, and PS5 haptics are not available in browsers;
+  rumble maps to Gamepad `dual-rumble` where supported.
+- HTTPS/WSS not terminated by the bridge; use a reverse proxy if you need
+  secure origins (required for gamepad on some browsers when not localhost).

--- a/webbridge/frontend/assets/icon.svg
+++ b/webbridge/frontend/assets/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="28" fill="#0a0c10"/>
+  <rect x="4" y="4" width="120" height="120" rx="24" fill="none" stroke="#0070d1" stroke-width="4"/>
+  <path d="M46 32 100 64 46 96z" fill="#0070d1"/>
+</svg>

--- a/webbridge/frontend/css/app.css
+++ b/webbridge/frontend/css/app.css
@@ -1,0 +1,444 @@
+/* chiaki-web — handwritten dark theme. Mobile-first. */
+
+:root {
+  --bg: #0a0c10;
+  --bg-raised: #12151c;
+  --bg-overlay: rgba(10, 12, 16, 0.88);
+  --line: #232833;
+  --text: #e8ecf2;
+  --text-dim: #8b94a3;
+  --accent: #0070d1;          /* PlayStation blue */
+  --accent-hi: #2f8fe6;
+  --danger: #d64545;
+  --ready: #3ecf6a;
+  --standby: #e8a13d;
+  --unknown: #5a6270;
+  --radius: 10px;
+  --font: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+  --mono: ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  overscroll-behavior: none;
+}
+
+body.streaming { overflow: hidden; }
+
+.hidden { display: none !important; }
+
+button { font: inherit; }
+kbd {
+  font-family: var(--mono);
+  font-size: 0.78em;
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-bottom-width: 2px;
+  border-radius: 5px;
+  padding: 1px 6px;
+}
+
+/* ── buttons ── */
+.btn {
+  background: var(--bg-raised);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 9px 16px;
+  min-height: 40px;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.btn:hover:not(:disabled) { border-color: var(--accent); }
+.btn:disabled { opacity: 0.45; cursor: default; }
+.btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  font-weight: 600;
+}
+.btn-primary:hover:not(:disabled) { background: var(--accent-hi); border-color: var(--accent-hi); }
+.btn-ghost { background: transparent; }
+.btn-danger { border-color: var(--danger); color: var(--danger); }
+.btn-danger:hover:not(:disabled) { background: var(--danger); color: #fff; border-color: var(--danger); }
+.btn-wide { display: block; width: 100%; margin-top: 10px; }
+
+/* ── hosts view shell ── */
+.view { min-height: 100%; }
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--line);
+}
+.brand { display: flex; align-items: center; gap: 10px; }
+.brand-mark { width: 22px; height: 22px; color: var(--accent); }
+.brand h1 { margin: 0; font-size: 1.15rem; font-weight: 700; letter-spacing: 0.04em; }
+.brand-accent { color: var(--accent); }
+.topbar-actions { display: flex; gap: 8px; }
+
+.banner {
+  margin: 14px 18px 0;
+  padding: 12px 16px;
+  background: #3a1520;
+  border: 1px solid var(--danger);
+  border-radius: var(--radius);
+  font-size: 0.92rem;
+}
+
+.hosts-main {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 26px;
+  padding: 18px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+@media (min-width: 760px) {
+  .hosts-main { grid-template-columns: 1fr 280px; }
+}
+
+.section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.section-head h2, .settings-col h2 {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-dim);
+}
+
+.card-list { display: grid; gap: 12px; }
+.card {
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+}
+.card-head { display: flex; align-items: center; gap: 10px; }
+.card-head h3 { margin: 0; font-size: 1.05rem; flex: 1; }
+.state-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--unknown);
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
+}
+.state-ready { background: var(--ready); box-shadow: 0 0 8px var(--ready); }
+.state-standby { background: var(--standby); box-shadow: 0 0 8px var(--standby); }
+.badge {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-hi);
+  border: 1px solid var(--accent);
+  border-radius: 20px;
+  padding: 2px 9px;
+}
+.card-meta { margin: 8px 0 12px; color: var(--text-dim); font-size: 0.88rem; }
+.card-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+
+.empty-note { color: var(--text-dim); }
+
+.settings-col { display: grid; gap: 12px; align-content: start; }
+.field { display: grid; gap: 5px; font-size: 0.9rem; }
+.field > span { color: var(--text-dim); }
+.field select, .field input[type="text"], .field input[type="number"] {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 9px 11px;
+  font: inherit;
+  min-height: 40px;
+}
+.field select:focus, .field input:focus { outline: none; border-color: var(--accent); }
+.field-row { grid-template-columns: auto 1fr; align-items: center; gap: 10px; }
+.field-row input[type="checkbox"] { width: 20px; height: 20px; accent-color: var(--accent); }
+
+.form-error { color: var(--danger); font-size: 0.88rem; min-height: 1.2em; margin: 4px 0; }
+
+.footer {
+  padding: 20px 18px;
+  color: var(--text-dim);
+  font-size: 0.78rem;
+  text-align: center;
+}
+
+/* ── stream view ── */
+#view-stream {
+  position: fixed;
+  inset: 0;
+  background: #000;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+#canvas-wrap { position: absolute; inset: 0; }
+.stream-canvas {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+  background: #000;
+}
+
+/* HUD: hidden until hover / tap, except the stats block when toggled on */
+.hud {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  font-size: 0.85rem;
+  z-index: 6; /* menu button stays tappable above the touch overlay */
+}
+.hud-top {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: calc(8px + env(safe-area-inset-top)) 14px 8px;
+  background: linear-gradient(rgba(0, 0, 0, 0.65), transparent);
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+#view-stream:hover .hud-top,
+#view-stream:focus-within .hud-top,
+#view-stream.hud-show .hud-top { opacity: 1; }
+@media (pointer: coarse) {
+  .hud-top { opacity: 1; } /* no hover on touch — keep the thin top bar */
+}
+#hud-nickname { font-weight: 600; }
+#hud-streaminfo { color: var(--text-dim); }
+.hud-menu-btn {
+  margin-left: auto;
+  pointer-events: auto;
+  min-width: 48px;
+  min-height: 44px;
+  border-color: transparent;
+}
+.hud-stats {
+  position: absolute;
+  left: 12px;
+  bottom: calc(12px + env(safe-area-inset-bottom));
+  margin: 0;
+  padding: 10px 12px;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  line-height: 1.5;
+  color: #b7e3ff;
+  background: rgba(0, 20, 40, 0.55);
+  border: 1px solid rgba(0, 112, 209, 0.4);
+  border-radius: 8px;
+  white-space: pre;
+}
+
+/* ── virtual gamepad overlay ── */
+.vpad {
+  position: absolute;
+  inset: 0;
+  display: none;
+  pointer-events: none;
+  touch-action: none;
+  z-index: 5;
+}
+.vpad-visible { display: block; }
+.vpad > * { pointer-events: auto; }
+
+.vpad-btn {
+  position: relative;
+  min-width: 48px;
+  min-height: 48px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.07);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 1.05rem;
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+}
+.vpad-btn.vpad-active {
+  background: rgba(0, 112, 209, 0.45);
+  border-color: var(--accent-hi);
+}
+
+.vpad-stick-zone {
+  position: absolute;
+  bottom: 8%;
+  width: 180px;
+  height: 180px;
+  touch-action: none;
+}
+.vpad-lstick-zone { left: 4%; }
+.vpad-rstick-zone { right: 4%; }
+.vpad-stick-base {
+  position: absolute;
+  inset: 15px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+}
+.vpad-stick-nub {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 64px;
+  height: 64px;
+  margin: -32px 0 0 -32px;
+  border-radius: 50%;
+  background: rgba(0, 112, 209, 0.4);
+  border: 1px solid var(--accent-hi);
+}
+
+.vpad-dpad {
+  position: absolute;
+  left: 4%;
+  bottom: calc(8% + 200px);
+  display: grid;
+  grid-template-areas: ". up ." "left . right" ". down .";
+  gap: 2px;
+}
+.vpad-dpad .vpad-btn { border-radius: 12px; font-size: 0.8rem; }
+.vpad-dpad-up { grid-area: up; }
+.vpad-dpad-down { grid-area: down; }
+.vpad-dpad-left { grid-area: left; }
+.vpad-dpad-right { grid-area: right; }
+
+.vpad-face {
+  position: absolute;
+  right: 4%;
+  bottom: calc(8% + 200px); /* above the right thumbstick */
+  display: grid;
+  grid-template-areas: ". pyramid ." "box . moon" ". cross .";
+  gap: 6px;
+}
+.vpad-face .vpad-btn { width: 58px; height: 58px; font-size: 1.35rem; }
+.vpad-face-pyramid { grid-area: pyramid; }
+.vpad-face-box { grid-area: box; }
+.vpad-face-moon { grid-area: moon; }
+.vpad-face-cross { grid-area: cross; }
+
+.vpad-shoulders {
+  position: absolute;
+  top: calc(10px + env(safe-area-inset-top));
+  display: flex;
+  gap: 8px;
+}
+.vpad-shoulders-left { left: 4%; }
+.vpad-shoulders-right { right: calc(4% + 64px); } /* clear the HUD menu button */
+.vpad-shoulder { border-radius: 14px; width: 74px; font-size: 0.85rem; }
+
+.vpad-system {
+  position: absolute;
+  left: 50%;
+  bottom: calc(10px + env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  display: flex;
+  gap: 10px;
+}
+.vpad-sys {
+  border-radius: 20px;
+  min-width: 56px;
+  min-height: 48px;
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+}
+
+/* Landscape phones are short (~375-430px tall): the default layout stacks the
+   dpad/face clusters 200px above the 180px sticks, which rides them off the top
+   of the screen (under the shoulder buttons/HUD). Compact everything and anchor
+   to the bottom safe-area so the whole pad fits. Tablets/portrait (taller) keep
+   the roomier default layout. */
+@media (orientation: landscape) and (max-height: 500px) {
+  .vpad-stick-zone {
+    width: 150px;
+    height: 150px;
+    bottom: calc(env(safe-area-inset-bottom) + 6px);
+  }
+  /* Drop the dpad/face into the mid-lower band and pull them inward toward the
+     centre (off the stick columns) so they're within easier thumb reach. They
+     clear the sticks horizontally (stick right edge = 4% + 150px). */
+  .vpad-dpad,
+  .vpad-face {
+    bottom: calc(env(safe-area-inset-bottom) + 96px);
+  }
+  .vpad-dpad { left: calc(4% + 158px); }
+  .vpad-face { right: calc(4% + 158px); }
+  .vpad-face .vpad-btn { width: 44px; height: 44px; font-size: 1.05rem; }
+  .vpad-face { gap: 5px; }
+  .vpad-dpad .vpad-btn { min-width: 42px; min-height: 42px; font-size: 0.72rem; }
+  .vpad-shoulder { min-height: 40px; width: 66px; font-size: 0.78rem; }
+}
+
+/* ── modals ── */
+.modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-overlay);
+  z-index: 20;
+  padding: 18px;
+}
+.modal-open { display: flex; }
+.modal-box {
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 22px;
+  width: min(440px, 100%);
+  max-height: 88vh;
+  overflow-y: auto;
+  display: grid;
+  gap: 12px;
+}
+.modal-box h2 { margin: 0 0 4px; font-size: 1.1rem; }
+.modal-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 6px; }
+.modal-menu-box { width: min(320px, 100%); }
+.modal-help-box { width: min(520px, 100%); }
+
+.help-table-el { border-collapse: collapse; width: 100%; font-size: 0.88rem; }
+.help-table-el td { padding: 5px 8px; border-bottom: 1px solid var(--line); }
+.help-table-el td:first-child { white-space: nowrap; }
+.help-note { color: var(--text-dim); font-size: 0.8rem; margin: 4px 0 0; }
+
+/* ── toasts ── */
+.toasts {
+  position: fixed;
+  bottom: calc(16px + env(safe-area-inset-bottom));
+  left: 50%;
+  transform: translateX(-50%);
+  display: grid;
+  gap: 8px;
+  z-index: 30;
+  pointer-events: none;
+  width: min(420px, calc(100vw - 32px));
+}
+.toast {
+  background: var(--bg-raised);
+  border: 1px solid var(--accent);
+  border-radius: 10px;
+  padding: 11px 16px;
+  font-size: 0.9rem;
+  text-align: center;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+.toast-show { opacity: 1; transform: translateY(0); }
+.toast-error { border-color: var(--danger); }

--- a/webbridge/frontend/index.html
+++ b/webbridge/frontend/index.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, user-scalable=no">
+  <meta name="theme-color" content="#0a0c10">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <title>chiaki-web</title>
+  <!-- use-credentials: manifest fetches are anonymous CORS by default, which
+       breaks behind cookie-based auth gates (e.g. Cloudflare Access) -->
+  <link rel="manifest" href="manifest.webmanifest" crossorigin="use-credentials">
+  <link rel="icon" href="assets/icon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="assets/icon.svg">
+  <link rel="stylesheet" href="css/app.css">
+</head>
+<body>
+  <!-- ══════════════ console list view ══════════════ -->
+  <div id="view-hosts" class="view">
+    <header class="topbar">
+      <div class="brand">
+        <svg class="brand-mark" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M5 3.5 19.5 12 5 20.5z" fill="currentColor"/>
+        </svg>
+        <h1>chiaki<span class="brand-accent">web</span></h1>
+      </div>
+      <div class="topbar-actions">
+        <button id="btn-demo" class="btn btn-ghost">Demo</button>
+        <button id="btn-refresh" class="btn btn-ghost" title="Rescan">Refresh</button>
+      </div>
+    </header>
+
+    <div id="banner-unsupported" class="banner hidden">
+      This browser does not support WebCodecs (VideoDecoder), which chiaki-web
+      needs for video. Use a recent Chrome, Edge or Safari.
+    </div>
+
+    <main class="hosts-main">
+      <section class="hosts-col">
+        <div class="section-head">
+          <h2>Consoles</h2>
+          <button id="btn-register-new" class="btn">Register a console</button>
+        </div>
+        <div id="host-list" class="card-list">
+          <p class="empty-note">Scanning…</p>
+        </div>
+      </section>
+
+      <aside class="settings-col">
+        <h2>Stream settings</h2>
+        <label class="field">
+          <span>Resolution</span>
+          <select id="set-resolution">
+            <option value="360p">360p</option>
+            <option value="540p">540p</option>
+            <option value="720p" selected>720p</option>
+            <option value="1080p">1080p</option>
+          </select>
+        </label>
+        <label class="field">
+          <span>Frame rate</span>
+          <select id="set-fps">
+            <option value="30">30 fps</option>
+            <option value="60" selected>60 fps</option>
+          </select>
+        </label>
+        <label class="field">
+          <span>Codec</span>
+          <select id="set-codec">
+            <option value="h264" selected>H.264</option>
+            <option value="hevc">HEVC (H.265)</option>
+          </select>
+        </label>
+        <label class="field">
+          <span>Bitrate (kbps, 0 = auto)</span>
+          <input id="set-bitrate" type="number" min="0" max="50000" step="1000" value="0">
+        </label>
+        <label class="field">
+          <span>Transport</span>
+          <select id="set-transport">
+            <option value="auto" selected>Auto (WebRTC, fall back to WebSocket)</option>
+            <option value="webrtc">WebRTC only (lowest latency)</option>
+            <option value="ws">WebSocket only (strict networks)</option>
+          </select>
+        </label>
+      </aside>
+    </main>
+
+    <footer class="footer">
+      <span id="app-version">chiaki-web</span>
+    </footer>
+  </div>
+
+  <!-- ══════════════ stream view ══════════════ -->
+  <div id="view-stream" class="view hidden">
+    <div id="canvas-wrap"><!-- canvas is created per session --></div>
+
+    <div class="hud">
+      <div class="hud-top">
+        <span id="hud-nickname"></span>
+        <span id="hud-streaminfo"></span>
+        <button id="btn-stream-menu" class="btn btn-ghost hud-menu-btn"
+                title="Menu (Esc)" aria-label="Stream menu">☰</button>
+      </div>
+      <pre id="hud-stats" class="hud-stats hidden"></pre>
+    </div>
+  </div>
+
+  <!-- ══════════════ modals ══════════════ -->
+  <div id="modal-register" class="modal">
+    <div class="modal-box">
+      <h2>Register console</h2>
+      <label class="field">
+        <span>Host (IP or name)</span>
+        <input id="reg-host" type="text" placeholder="192.168.1.42" autocomplete="off">
+      </label>
+      <label class="field field-row">
+        <input id="reg-ps5" type="checkbox" checked>
+        <span>PlayStation 5</span>
+      </label>
+      <label class="field">
+        <span>PIN (from Remote Play settings on the console)</span>
+        <input id="reg-pin" type="text" inputmode="numeric" pattern="[0-9]*"
+               placeholder="12345678" autocomplete="off">
+      </label>
+      <label class="field">
+        <span>PSN Account ID (base64)</span>
+        <input id="reg-psn" type="text" placeholder="xxxxxxxxxxx=" autocomplete="off">
+      </label>
+      <p id="reg-error" class="form-error"></p>
+      <div class="modal-actions">
+        <button id="reg-cancel" class="btn">Cancel</button>
+        <button id="reg-submit" class="btn btn-primary">Register</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="modal-pin" class="modal">
+    <div class="modal-box">
+      <h2>Login PIN</h2>
+      <p id="pin-msg"></p>
+      <label class="field">
+        <span>PIN</span>
+        <input id="pin-input" type="text" inputmode="numeric" pattern="[0-9]*"
+               placeholder="0000" autocomplete="off">
+      </label>
+      <div class="modal-actions">
+        <button id="pin-cancel" class="btn">Cancel</button>
+        <button id="pin-submit" class="btn btn-primary">Send</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="modal-menu" class="modal">
+    <div class="modal-box modal-menu-box">
+      <h2>Stream menu</h2>
+      <button id="menu-mic" class="btn btn-wide">Microphone: off</button>
+      <button id="menu-transport" class="btn btn-wide">Transport: WebRTC</button>
+      <button id="menu-stats" class="btn btn-wide">Toggle stats</button>
+      <button id="menu-fullscreen" class="btn btn-wide">Toggle fullscreen</button>
+      <button id="menu-help" class="btn btn-wide">Controls help</button>
+      <button id="menu-disconnect" class="btn btn-wide btn-danger">Disconnect</button>
+    </div>
+  </div>
+
+  <div id="modal-help" class="modal">
+    <div class="modal-box modal-help-box">
+      <h2>Keyboard &amp; mouse controls</h2>
+      <table class="help-table-el">
+        <tbody id="help-table"></tbody>
+      </table>
+      <p class="help-note">Press <kbd>F1</kbd> or <kbd>?</kbd> to close.</p>
+    </div>
+  </div>
+
+  <div id="toasts" class="toasts"></div>
+
+  <script type="module" src="js/app.js"></script>
+</body>
+</html>

--- a/webbridge/frontend/js/app.js
+++ b/webbridge/frontend/js/app.js
@@ -1,0 +1,729 @@
+/**
+ * app.js — chiaki-web UI flow.
+ *
+ * Console list view (discovery, wake, register, settings) and the stream
+ * view (WebRTC session, video worker, input, HUD). Everything talks to the
+ * bridge per webbridge/PROTOCOL.md.
+ */
+
+import { Signaling, api } from './signaling.js';
+import { RtcSession } from './webrtc.js';
+import { WsSession } from './ws-transport.js';
+import { VideoPipeline } from './video.js';
+import { InputManager, KEY_MAP, KEY_HELP_EXTRA } from './input.js';
+import { VirtualGamepad, isTouchDevice } from './virtual-gamepad.js';
+import { MicCapture } from './mic.js';
+import { toast, openModal, Hud, renderKeyHelp } from './ui.js';
+
+const $ = (id) => document.getElementById(id);
+
+const SETTINGS_KEY = 'chiaki-web.settings';
+// Auto: prefer WebRTC (works via the libnice ICE backend + Cloudflare TURN,
+// even for relay-only remote clients), fall back to WebSocket if it can't
+// connect. The bridge must run with CHIAKI_ICE_BACKEND=nice for remote WebRTC.
+const DEFAULT_SETTINGS = { resolution: '720p', fps: 60, codec: 'h264', bitrate: 0, transport: 'auto' };
+// How long WebRTC gets to become ready before "auto" falls back to the
+// WebSocket transport. TURN allocation + ICE on a hostile network is slow,
+// but past this it's essentially never going to connect.
+const WEBRTC_FALLBACK_TIMEOUT_MS = 15000;
+
+/** @type {{wsPort: number, name?: string, version?: string}} */
+let bridgeInfo = { wsPort: 9081 };
+/** @type {ActiveSession|null} */
+let session = null;
+
+/* ────────────────────────────── settings ────────────────────────────── */
+
+function loadSettings() {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (raw) return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
+  } catch (e) {
+    /* corrupted settings — fall back */
+  }
+  return { ...DEFAULT_SETTINGS };
+}
+
+function saveSettings(s) {
+  try {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(s));
+  } catch (e) {
+    /* private mode */
+  }
+}
+
+function bindSettingsPanel() {
+  const s = loadSettings();
+  $('set-resolution').value = s.resolution;
+  $('set-fps').value = String(s.fps);
+  $('set-codec').value = s.codec;
+  $('set-bitrate').value = String(s.bitrate || 0);
+  $('set-transport').value = s.transport || 'auto';
+  const update = () => {
+    saveSettings({
+      resolution: $('set-resolution').value,
+      fps: parseInt($('set-fps').value, 10),
+      codec: $('set-codec').value,
+      bitrate: parseInt($('set-bitrate').value, 10) || 0,
+      transport: $('set-transport').value,
+    });
+  };
+  for (const id of ['set-resolution', 'set-fps', 'set-codec', 'set-bitrate', 'set-transport']) {
+    $(id).addEventListener('change', update);
+  }
+}
+
+/* ─────────────────────────── console list view ───────────────────────── */
+
+async function refreshHosts() {
+  const list = $('host-list');
+  try {
+    const res = await api('api/hosts');
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const hosts = await res.json();
+    renderHosts(Array.isArray(hosts) ? hosts : []);
+  } catch (e) {
+    list.textContent = '';
+    const err = document.createElement('p');
+    err.className = 'empty-note';
+    err.textContent = 'Could not reach the bridge (' + e.message + ')';
+    list.appendChild(err);
+  }
+}
+
+/** @param {Array<object>} hosts */
+function renderHosts(hosts) {
+  const list = $('host-list');
+  list.textContent = '';
+  if (hosts.length === 0) {
+    const p = document.createElement('p');
+    p.className = 'empty-note';
+    p.textContent = 'No consoles found. Register one manually, or try Demo mode.';
+    list.appendChild(p);
+    return;
+  }
+  for (const h of hosts) {
+    list.appendChild(hostCard(h));
+  }
+}
+
+/** @param {object} h — /api/hosts entry */
+function hostCard(h) {
+  const card = document.createElement('article');
+  card.className = 'card';
+
+  const head = document.createElement('div');
+  head.className = 'card-head';
+  const dot = document.createElement('span');
+  dot.className = 'state-dot state-' + (h.state || 'unknown');
+  dot.title = h.state || 'unknown';
+  const name = document.createElement('h3');
+  name.textContent = h.nickname || h.host;
+  head.append(dot, name);
+  if (h.registered) {
+    const badge = document.createElement('span');
+    badge.className = 'badge';
+    badge.textContent = 'registered';
+    head.appendChild(badge);
+  }
+
+  const meta = document.createElement('p');
+  meta.className = 'card-meta';
+  const bits = [h.ps5 ? 'PS5' : 'PS4', h.host, h.state || 'unknown'];
+  if (h.appName) bits.push('▶ ' + h.appName);
+  meta.textContent = bits.join('  ·  ');
+
+  const actions = document.createElement('div');
+  actions.className = 'card-actions';
+
+  const connectBtn = document.createElement('button');
+  connectBtn.className = 'btn btn-primary';
+  connectBtn.textContent = 'Connect';
+  connectBtn.disabled = !h.registered;
+  connectBtn.title = h.registered ? '' : 'Register this console first';
+  connectBtn.addEventListener('click', () => startStream({ host: h.host }));
+  actions.appendChild(connectBtn);
+
+  const wakeBtn = document.createElement('button');
+  wakeBtn.className = 'btn';
+  wakeBtn.textContent = 'Wake';
+  wakeBtn.disabled = !h.registered;
+  wakeBtn.addEventListener('click', async () => {
+    wakeBtn.disabled = true;
+    try {
+      const res = await api('api/wakeup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ host: h.host }),
+      });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      toast('Wake signal sent to ' + (h.nickname || h.host));
+    } catch (e) {
+      toast('Wake failed: ' + e.message, 'error');
+    } finally {
+      wakeBtn.disabled = false;
+    }
+  });
+  actions.appendChild(wakeBtn);
+
+  const regBtn = document.createElement('button');
+  regBtn.className = 'btn';
+  regBtn.textContent = h.registered ? 'Re-register' : 'Register';
+  regBtn.addEventListener('click', () => openRegisterDialog(h.host, !!h.ps5));
+  actions.appendChild(regBtn);
+
+  card.append(head, meta, actions);
+  return card;
+}
+
+/* ───────────────────────────── registration ──────────────────────────── */
+
+/** @param {string} [host] @param {boolean} [ps5] */
+function openRegisterDialog(host, ps5 = true) {
+  $('reg-host').value = host || '';
+  $('reg-ps5').checked = ps5;
+  $('reg-pin').value = '';
+  $('reg-error').textContent = '';
+  const close = openModal($('modal-register'));
+  $('reg-cancel').onclick = close;
+  $('reg-submit').onclick = async () => {
+    const body = {
+      host: $('reg-host').value.trim(),
+      ps5: $('reg-ps5').checked,
+      pin: parseInt($('reg-pin').value, 10),
+      psnAccountId: $('reg-psn').value.trim(),
+    };
+    if (!body.host || Number.isNaN(body.pin) || !body.psnAccountId) {
+      $('reg-error').textContent = 'Host, PIN and PSN Account ID are all required.';
+      return;
+    }
+    $('reg-submit').disabled = true;
+    $('reg-error').textContent = 'Registering… (this can take a few seconds)';
+    try {
+      const res = await api('api/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'HTTP ' + res.status);
+      toast('Registered ' + (data.nickname || body.host));
+      close();
+      refreshHosts();
+    } catch (e) {
+      $('reg-error').textContent = 'Registration failed: ' + e.message;
+    } finally {
+      $('reg-submit').disabled = false;
+    }
+  };
+}
+
+/* ────────────────────────────── stream view ──────────────────────────── */
+
+class ActiveSession {
+  /** @param {{host?: string, demo?: boolean}} target */
+  constructor(target) {
+    this.target = target;
+    this.closed = false;
+    this.hud = new Hud();
+    /** @type {VideoPipeline|null} */
+    this.pipeline = null;
+    /** @type {WakeLockSentinel|null} */
+    this.wakeLock = null;
+    this.closeMenu = null;
+    this.closePin = null;
+    this.streamCodec = loadSettings().codec;
+
+    // Fresh canvas per session: transferControlToOffscreen is one-shot.
+    const wrap = $('canvas-wrap');
+    wrap.textContent = '';
+    this.canvas = document.createElement('canvas');
+    this.canvas.className = 'stream-canvas';
+    this.canvas.width = 1280;
+    this.canvas.height = 720;
+    wrap.appendChild(this.canvas);
+
+    this.signaling = new Signaling(bridgeInfo.wsPort);
+    /** @type {RtcSession|WsSession|null} — one common surface (see ws-transport.js) */
+    this.rtc = null;
+    this.transportMode = loadSettings().transport || 'auto'; // auto | webrtc | ws
+    this.useWs = this.transportMode === 'ws';
+    /** @type {RTCIceServer[]} minted by the bridge (Cloudflare TURN) */
+    this.iceServers = [];
+    this._fellBack = false;
+    this._rtcDeadline = null;
+
+    this.input = new InputManager({
+      send: (msg) => this.rtc && this.rtc.sendInput(msg),
+      onGamepadActive: (active) => this._updateOverlayVisibility(active),
+      onToggleHelp: () => this._toggleHelp(),
+      onMenu: () => this._toggleMenu(),
+      onUserGesture: () => this._onGesture(),
+    });
+    this.vpad = new VirtualGamepad($('view-stream'), this.input);
+
+    this._onVisibility = () => {
+      if (document.visibilityState === 'visible') this._acquireWakeLock();
+    };
+    this._onFsGesture = () => this._onGesture();
+  }
+
+  async start() {
+    showView('stream');
+    this.hud.setNickname(this.target.demo ? 'Demo' : this.target.host || '');
+    $('hud-streaminfo').textContent = 'connecting…';
+
+    try {
+      await this.signaling.connect();
+    } catch (e) {
+      this.teardown('Bridge signaling unreachable', true);
+      return;
+    }
+    if (this.closed) return;
+
+    this.signaling.onclose = (byUs) => {
+      if (!byUs && !this.closed) this.teardown('Connection to bridge lost', true);
+    };
+    this.signaling.onmessage = (msg) => this._onSignal(msg);
+
+    // Remote diagnostics: surface client-side errors in the bridge log.
+    this.signaling.log('[client] ' + navigator.userAgent + ' | WebCodecs=' + !!window.VideoDecoder);
+    this._onWindowError = (e) => {
+      this.signaling.log('[client] error: ' + (e.message || (e.reason && (e.reason.stack || e.reason.message)) || 'unknown'));
+    };
+    window.addEventListener('error', this._onWindowError);
+    window.addEventListener('unhandledrejection', this._onWindowError);
+
+    if (this.useWs) {
+      this._createTransport('ws');
+    }
+    // WebRTC transport is created lazily at the bridge's offer, so the
+    // minted TURN servers (an "iceServers" signaling message) can be in the
+    // RTCPeerConnection configuration from the start.
+
+    const s = loadSettings();
+    const startMsg = {
+      resolution: s.resolution,
+      fps: s.fps,
+      codec: s.codec,
+      transport: this.useWs ? 'ws' : 'webrtc',
+    };
+    if (s.bitrate > 0) startMsg.bitrate = s.bitrate;
+    if (this.target.demo) startMsg.demo = true;
+    else startMsg.host = this.target.host;
+    this.signaling.start(startMsg);
+
+    this.input.attach($('view-stream'));
+    this._updateOverlayVisibility(this.input.gamepadSeen);
+    this._acquireWakeLock();
+    document.addEventListener('visibilitychange', this._onVisibility);
+    // Any tap doubles as the iOS audio-unlock gesture.
+    $('view-stream').addEventListener('pointerdown', this._onFsGesture);
+
+    // Immersive mode: best-effort, silently tolerated failures (iOS).
+    try {
+      await $('view-stream').requestFullscreen({ navigationUI: 'hide' });
+    } catch (e) {
+      /* not available / denied */
+    }
+    try {
+      if (screen.orientation && screen.orientation.lock) {
+        await screen.orientation.lock('landscape');
+      }
+    } catch (e) {
+      /* unsupported (iOS) or not in fullscreen */
+    }
+
+    // Stats: worker posts decode stats; we add DC bitrate.
+    this._statsTimer = setInterval(async () => {
+      if (this.rtc) this.hud.noteBytes(await this.rtc.getVideoBytesReceived());
+    }, 1000);
+
+    $('btn-stream-menu').onclick = () => this._toggleMenu();
+  }
+
+  /**
+   * Create the media transport and wire the handlers shared by both kinds.
+   * @param {'webrtc'|'ws'} kind
+   */
+  _createTransport(kind) {
+    const t = kind === 'ws'
+      ? new WsSession(this.signaling)
+      : new RtcSession(this.signaling, this.iceServers);
+    this.rtc = t;
+    t.onVideoData = (buf) => {
+      if (this.pipeline) this.pipeline.pushFragment(buf);
+    };
+    t.onInputMessage = (msg) => this._onInputMessage(msg);
+    t.onConnectionState = (st) => {
+      this.signaling.log('[' + kind + '] connection state: ' + st);
+      if (st === 'failed' && kind === 'webrtc') this._webrtcFailed('WebRTC connection failed');
+    };
+    t.onReady = () => {
+      this._clearRtcDeadline();
+      $('hud-streaminfo').textContent = '';
+      if (this.streamInfo) this.hud.setStreamInfo(this.streamInfo);
+    };
+    if (kind === 'webrtc' && this.transportMode === 'auto') {
+      // Belt for the cases ICE never reaches "failed" (silent UDP blackhole).
+      this._rtcDeadline = setTimeout(
+        () => this._webrtcFailed('WebRTC timed out'),
+        WEBRTC_FALLBACK_TIMEOUT_MS,
+      );
+    }
+  }
+
+  _clearRtcDeadline() {
+    if (this._rtcDeadline) {
+      clearTimeout(this._rtcDeadline);
+      this._rtcDeadline = null;
+    }
+  }
+
+  /**
+   * Swap to the WebSocket transport mid-session (the bridge keeps the
+   * console session alive). Used by the auto fallback and the stream menu.
+   * @param {string} why — shown as a toast
+   */
+  _switchToWs(why) {
+    if (this.closed || this._fellBack || (this.rtc && this.rtc.isWs)) return;
+    this._clearRtcDeadline();
+    this._fellBack = true;
+    this.signaling.log('[transport] switching to WebSocket: ' + why);
+    toast(why);
+    if (this.mic && this.mic.running) this._toggleMic(); // mic rode the old DCs
+    if (this.rtc) this.rtc.close();
+    this._createTransport('ws');
+    if (this.pipeline) this.pipeline.resetStream(); // frameIds restart at 0
+    this.signaling.switchTransport('ws');
+  }
+
+  /**
+   * WebRTC didn't make it. In auto mode, fall back; otherwise end.
+   * @param {string} reason
+   */
+  _webrtcFailed(reason) {
+    if (this.closed || this._fellBack || this.useWs) return;
+    if (this.transportMode !== 'auto') {
+      this._clearRtcDeadline();
+      this.teardown(reason, true);
+      return;
+    }
+    this.signaling.log('[transport] ' + reason);
+    this._switchToWs('WebRTC failed — falling back to WebSocket transport');
+  }
+
+  /** @param {object} msg — signaling message from the bridge */
+  _onSignal(msg) {
+    // "t"-keyed messages are bridge→browser events riding the signaling
+    // socket (WebSocket transport mode).
+    if (msg.type === undefined && msg.t !== undefined) {
+      this._onInputMessage(msg);
+      return;
+    }
+    switch (msg.type) {
+      case 'streamInfo':
+        this.streamInfo = msg;
+        this.streamCodec = msg.codec === 'hevc' ? 'hevc' : 'h264';
+        this.hud.setStreamInfo(msg);
+        this._createPipeline();
+        break;
+      case 'iceServers':
+        // Arrives before the offer; used when the RtcSession is constructed.
+        this.iceServers = Array.isArray(msg.iceServers) ? msg.iceServers : [];
+        break;
+      case 'offer':
+        if (!this.pipeline) this._createPipeline();
+        if (!this.rtc) this._createTransport('webrtc');
+        if (this.rtc.isWs) break; // stale offer after fallback
+        this.rtc.acceptOffer(msg.sdp).catch((e) => {
+          this._webrtcFailed('SDP negotiation failed: ' + e.message);
+        });
+        break;
+      case 'candidate':
+        if (this.rtc && !this.rtc.isWs) this.rtc.addRemoteCandidate(msg.candidate, msg.mid);
+        break;
+      case 'audioInfo':
+        if (this.rtc && this.rtc.isWs) this.rtc.handleSignal(msg);
+        break;
+      case 'status':
+        if (msg.state === 'connecting') $('hud-streaminfo').textContent = 'connecting…';
+        if (msg.state === 'connected' && this.rtc && this.rtc.isWs) this.rtc.handleSignal(msg);
+        break;
+      case 'quit':
+        this.teardown(msg.reason || 'session ended', !!msg.error);
+        break;
+      default:
+        break; // unknown types: tolerate
+    }
+  }
+
+  _createPipeline() {
+    if (this.pipeline) return;
+    this.pipeline = new VideoPipeline(this.canvas, this.streamCodec, {
+      requestIdr: () => this.rtc && this.rtc.sendInput({ t: 'idr' }),
+      onStats: (s) => this.hud.update(s),
+      onFirstFrame: () => {
+        $('hud-streaminfo').textContent = '';
+        this.signaling.log('[video] first frame rendered');
+      },
+      onFatal: (msg) => {
+        this.signaling.log('[video] FATAL: ' + msg);
+        this.teardown(msg, true);
+      },
+      onLog: (msg) => this.signaling.log(msg),
+    });
+  }
+
+  /** @param {object} msg — bridge → browser message on the input DC */
+  _onInputMessage(msg) {
+    switch (msg.t) {
+      case 'rumble':
+        this.input.rumble(msg);
+        break;
+      case 'pinRequest':
+        this._showPinDialog(!!msg.incorrect);
+        break;
+      case 'nickname':
+        this.hud.setNickname(msg.name || '');
+        break;
+      case 'led':
+      case 'stats':
+        break; // informational
+      default:
+        break; // forward-compatible: ignore unknown types
+    }
+  }
+
+  _showPinDialog(incorrect) {
+    if (this.closePin) this.closePin();
+    $('pin-msg').textContent = incorrect
+      ? 'Incorrect PIN — try again.'
+      : 'The console is asking for a login PIN.';
+    $('pin-input').value = '';
+    this.closePin = openModal($('modal-pin'), { sticky: true });
+    $('pin-input').focus();
+    $('pin-submit').onclick = () => {
+      const pin = $('pin-input').value.trim();
+      if (!/^\d{4,8}$/.test(pin)) {
+        $('pin-msg').textContent = 'Enter the numeric PIN shown on the console.';
+        return;
+      }
+      this.rtc.sendInput({ t: 'pin', pin });
+      this.closePin();
+      this.closePin = null;
+    };
+    $('pin-cancel').onclick = () => {
+      if (this.closePin) this.closePin();
+      this.closePin = null;
+    };
+  }
+
+  _updateOverlayVisibility(gamepadActive) {
+    if (!this.vpad) return;
+    if (isTouchDevice() && !gamepadActive) this.vpad.show();
+    else this.vpad.hide();
+  }
+
+  _onGesture() {
+    if (this.rtc) this.rtc.resumeAudio();
+  }
+
+  async _acquireWakeLock() {
+    if (this.closed || !('wakeLock' in navigator)) return;
+    try {
+      this.wakeLock = await navigator.wakeLock.request('screen');
+    } catch (e) {
+      /* denied (battery saver, background tab) */
+    }
+  }
+
+  _toggleMenu() {
+    if (this.closeMenu) {
+      this.closeMenu();
+      this.closeMenu = null;
+      return;
+    }
+    this.closeMenu = openModal($('modal-menu'), { onClose: () => (this.closeMenu = null) });
+    $('menu-disconnect').onclick = () => this.teardown('Disconnected', false);
+    $('menu-mic').textContent = 'Microphone: ' + (this.mic && this.mic.running ? 'ON' : 'off');
+    $('menu-mic').onclick = () => {
+      this._toggleMic();
+      this.closeMenu();
+    };
+    const onWs = this.rtc && this.rtc.isWs;
+    $('menu-transport').textContent = 'Transport: ' + (onWs ? 'WebSocket' : 'WebRTC');
+    // WebRTC→WS is a live swap; going back would need full renegotiation, so
+    // returning to WebRTC means reconnecting.
+    $('menu-transport').disabled = !!onWs;
+    $('menu-transport').title = onWs
+      ? 'Already on WebSocket — disconnect and reconnect to use WebRTC'
+      : 'Switch this session to the WebSocket transport';
+    $('menu-transport').onclick = () => {
+      this.closeMenu();
+      this._switchToWs('Switched to WebSocket transport');
+    };
+    $('menu-stats').onclick = () => {
+      this.hud.toggle();
+      this.closeMenu();
+    };
+    $('menu-fullscreen').onclick = async () => {
+      try {
+        if (document.fullscreenElement) await document.exitFullscreen();
+        else await $('view-stream').requestFullscreen({ navigationUI: 'hide' });
+      } catch (e) {
+        /* unsupported */
+      }
+      this.closeMenu();
+    };
+    $('menu-help').onclick = () => {
+      this.closeMenu();
+      this._toggleHelp();
+    };
+  }
+
+  async _toggleMic() {
+    if (this.mic && this.mic.running) {
+      this.mic.stop();
+      if (this.rtc) this.rtc.sendInput({ t: 'micOff' });
+      toast('Microphone off');
+      return;
+    }
+    if (!this.mic) {
+      this.mic = new MicCapture({
+        send: (buf) => this.rtc && this.rtc.sendMic(buf),
+        log: (msg) => this.signaling.log(msg),
+      });
+    }
+    try {
+      await this.mic.start();
+      if (this.rtc) this.rtc.sendInput({ t: 'micOn' });
+      toast('Microphone ON');
+    } catch (e) {
+      this.signaling.log('[mic] ' + e.message);
+      toast(e.message, 'error');
+    }
+  }
+
+  _toggleHelp() {
+    const m = $('modal-help');
+    if (m.classList.contains('modal-open')) {
+      m.classList.remove('modal-open');
+    } else {
+      openModal(m);
+    }
+  }
+
+  /**
+   * Tear the whole session down and return to the console list.
+   * @param {string} reason @param {boolean} isError
+   */
+  teardown(reason, isError) {
+    if (this.closed) return;
+    this.closed = true;
+
+    clearInterval(this._statsTimer);
+    this._clearRtcDeadline();
+    if (this.closeMenu) this.closeMenu();
+    if (this.closePin) this.closePin();
+    $('modal-help').classList.remove('modal-open');
+
+    this.input.detach();
+    this.vpad.destroy();
+    if (this.mic && this.mic.running) this.mic.stop();
+    if (this.pipeline) this.pipeline.destroy();
+    if (this.rtc) this.rtc.close();
+    this.signaling.stop();
+
+    document.removeEventListener('visibilitychange', this._onVisibility);
+    $('view-stream').removeEventListener('pointerdown', this._onFsGesture);
+    if (this._onWindowError) {
+      window.removeEventListener('error', this._onWindowError);
+      window.removeEventListener('unhandledrejection', this._onWindowError);
+    }
+    if (this.wakeLock) {
+      this.wakeLock.release().catch(() => {});
+      this.wakeLock = null;
+    }
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {});
+    }
+    if (screen.orientation && screen.orientation.unlock) {
+      try {
+        screen.orientation.unlock();
+      } catch (e) {
+        /* fine */
+      }
+    }
+    this.hud.hideStats();
+
+    session = null;
+    showView('hosts');
+    refreshHosts();
+    if (reason) toast(reason, isError ? 'error' : 'info');
+  }
+}
+
+/** @param {{host?: string, demo?: boolean}} target */
+function startStream(target) {
+  if (session) return;
+  if (typeof VideoDecoder === 'undefined') {
+    toast('This browser has no WebCodecs support — cannot stream.', 'error');
+    return;
+  }
+  session = new ActiveSession(target);
+  session.start();
+}
+
+/* ─────────────────────────────── shell ───────────────────────────────── */
+
+/** @param {'hosts'|'stream'} which */
+function showView(which) {
+  $('view-hosts').classList.toggle('hidden', which !== 'hosts');
+  $('view-stream').classList.toggle('hidden', which !== 'stream');
+  document.body.classList.toggle('streaming', which === 'stream');
+}
+
+async function init() {
+  if (typeof VideoDecoder === 'undefined') {
+    $('banner-unsupported').classList.remove('hidden');
+  }
+
+  bindSettingsPanel();
+  renderKeyHelp(KEY_MAP, KEY_HELP_EXTRA);
+
+  $('btn-refresh').addEventListener('click', refreshHosts);
+  $('btn-register-new').addEventListener('click', () => openRegisterDialog());
+  $('btn-demo').addEventListener('click', () => startStream({ demo: true }));
+
+  // Never zoom: this is a gamepad UI, and iOS Safari ignores user-scalable=no.
+  // Kill pinch-zoom (gesture* events) and double-tap-to-zoom (two taps within
+  // ~350 ms) at the document level. Single taps are untouched, so button
+  // presses and list clicks still work.
+  document.addEventListener('gesturestart', (e) => e.preventDefault());
+  document.addEventListener('gesturechange', (e) => e.preventDefault());
+  let lastTouchEnd = 0;
+  document.addEventListener('touchend', (e) => {
+    const now = Date.now();
+    if (now - lastTouchEnd <= 350) e.preventDefault();
+    lastTouchEnd = now;
+  }, { passive: false });
+  $('view-stream').addEventListener('dblclick', (e) => e.preventDefault());
+
+  try {
+    const res = await api('api/info');
+    if (res.ok) {
+      const info = await res.json();
+      if (info && typeof info.wsPort === 'number') bridgeInfo = info;
+      if (info.version) {
+        $('app-version').textContent = (info.name || 'chiaki-web') + ' ' + info.version;
+      }
+    }
+  } catch (e) {
+    toast('Bridge /api/info unreachable — using default WS port 9081', 'error');
+  }
+
+  refreshHosts();
+}
+
+init();

--- a/webbridge/frontend/js/input.js
+++ b/webbridge/frontend/js/input.js
@@ -51,7 +51,6 @@ export const TOUCHPAD_W = 1920;
 export const TOUCHPAD_H = 942;
 
 const STICK_MAX = 32767;
-const DEADZONE = 0.1;
 
 /**
  * Keyboard map, also rendered by the help overlay. code → action.
@@ -92,9 +91,9 @@ export const KEY_HELP_EXTRA = [
   { keys: 'Esc', label: 'Stream menu' },
 ];
 
-/** @param {number} v -1..1 → i16, with per-axis deadzone. */
+/** @param {number} v -1..1 → i16 (linear passthrough — no deadzone, no
+ *  anti-deadzone; the console applies its own deadzone). */
 function axisToI16(v) {
-  if (Math.abs(v) < DEADZONE) return 0;
   const s = Math.round(v * STICK_MAX);
   return Math.max(-STICK_MAX, Math.min(STICK_MAX, s));
 }

--- a/webbridge/frontend/js/input.js
+++ b/webbridge/frontend/js/input.js
@@ -1,0 +1,358 @@
+/**
+ * input.js — merges keyboard, Gamepad API and the virtual touch overlay into
+ * one controller state, sent on the input DataChannel as
+ * `{"t":"cs", b, l2, r2, lx, ly, rx, ry, tp}` (PROTOCOL.md "Input DC").
+ *
+ * Send policy: poll at 60 Hz, transmit on change, and at least every 200 ms
+ * as a keepalive.
+ */
+
+/** Chiaki button bitmask (PROTOCOL.md). */
+export const BTN = {
+  CROSS: 1 << 0,
+  MOON: 1 << 1,
+  BOX: 1 << 2,
+  PYRAMID: 1 << 3,
+  DPAD_LEFT: 1 << 4,
+  DPAD_RIGHT: 1 << 5,
+  DPAD_UP: 1 << 6,
+  DPAD_DOWN: 1 << 7,
+  L1: 1 << 8,
+  R1: 1 << 9,
+  L3: 1 << 10,
+  R3: 1 << 11,
+  OPTIONS: 1 << 12,
+  SHARE: 1 << 13,
+  TOUCHPAD: 1 << 14,
+  PS: 1 << 15,
+};
+
+/** W3C standard-mapping gamepad button index → chiaki flag (6/7 are analog). */
+const GAMEPAD_MAP = {
+  0: BTN.CROSS,
+  1: BTN.MOON,
+  2: BTN.BOX,
+  3: BTN.PYRAMID,
+  4: BTN.L1,
+  5: BTN.R1,
+  8: BTN.SHARE,
+  9: BTN.OPTIONS,
+  10: BTN.L3,
+  11: BTN.R3,
+  12: BTN.DPAD_UP,
+  13: BTN.DPAD_DOWN,
+  14: BTN.DPAD_LEFT,
+  15: BTN.DPAD_RIGHT,
+  16: BTN.PS,
+};
+
+/** DualShock touchpad plane (PROTOCOL.md). */
+export const TOUCHPAD_W = 1920;
+export const TOUCHPAD_H = 942;
+
+const STICK_MAX = 32767;
+const DEADZONE = 0.1;
+
+/**
+ * Keyboard map, also rendered by the help overlay. code → action.
+ *
+ * Layout follows FPS keyboard conventions (WASD = movement, Shift = aim,
+ * R = fire, Space = jump) with mnemonics where they don't conflict
+ * (C = Circle, T = Triangle, O = Options, P = PS). Ctrl is deliberately
+ * unused: holding it as a button while pressing W/R/T would trigger
+ * close-tab / reload / new-tab in the browser.
+ */
+export const KEY_MAP = [
+  { keys: ['Space', 'Enter'], label: 'Cross — jump / confirm', btn: BTN.CROSS },
+  { keys: ['KeyC', 'Backspace'], label: 'Circle — dodge / back', btn: BTN.MOON },
+  { keys: ['KeyF'], label: 'Square — interact / reload', btn: BTN.BOX },
+  { keys: ['KeyT'], label: 'Triangle — swap / special', btn: BTN.PYRAMID },
+  { keys: ['ArrowUp'], label: 'D-pad up', btn: BTN.DPAD_UP },
+  { keys: ['ArrowDown'], label: 'D-pad down', btn: BTN.DPAD_DOWN },
+  { keys: ['ArrowLeft'], label: 'D-pad left', btn: BTN.DPAD_LEFT },
+  { keys: ['ArrowRight'], label: 'D-pad right', btn: BTN.DPAD_RIGHT },
+  { keys: ['KeyQ'], label: 'L1', btn: BTN.L1 },
+  { keys: ['KeyE'], label: 'R1', btn: BTN.R1 },
+  { keys: ['ShiftLeft', 'ShiftRight'], label: 'L2 — aim', trigger: 'l2' },
+  { keys: ['KeyR'], label: 'R2 — fire', trigger: 'r2' },
+  { keys: ['KeyX'], label: 'L3 — left stick click', btn: BTN.L3 },
+  { keys: ['KeyM'], label: 'R3 — right stick click', btn: BTN.R3 },
+  { keys: ['KeyO'], label: 'Options', btn: BTN.OPTIONS },
+  { keys: ['Tab'], label: 'Share / Create', btn: BTN.SHARE },
+  { keys: ['KeyG'], label: 'Touchpad click', btn: BTN.TOUCHPAD },
+  { keys: ['KeyP'], label: 'PS home', btn: BTN.PS },
+];
+
+/** Non-button helper rows for the help overlay. */
+export const KEY_HELP_EXTRA = [
+  { keys: 'W A S D', label: 'Left stick (movement) — or d-pad after F2' },
+  { keys: 'I J K L', label: 'Right stick (camera)' },
+  { keys: 'F2', label: 'Toggle WASD: left stick ↔ d-pad' },
+  { keys: 'F1 or ?', label: 'This help' },
+  { keys: 'Esc', label: 'Stream menu' },
+];
+
+/** @param {number} v -1..1 → i16, with per-axis deadzone. */
+function axisToI16(v) {
+  if (Math.abs(v) < DEADZONE) return 0;
+  const s = Math.round(v * STICK_MAX);
+  return Math.max(-STICK_MAX, Math.min(STICK_MAX, s));
+}
+
+/** Larger-magnitude wins when two sources drive the same stick axis. */
+function domAxis(a, b) {
+  return Math.abs(b) > Math.abs(a) ? b : a;
+}
+
+export class InputManager {
+  /**
+   * @param {{
+   *   send: (msg: object) => void,
+   *   onGamepadActive?: (active: boolean) => void,
+   *   onToggleHelp?: () => void,
+   *   onMenu?: () => void,
+   *   onUserGesture?: () => void,
+   * }} opts
+   */
+  constructor(opts) {
+    this.send = opts.send;
+    this.onGamepadActive = opts.onGamepadActive || (() => {});
+    this.onToggleHelp = opts.onToggleHelp || (() => {});
+    this.onMenu = opts.onMenu || (() => {});
+    this.onUserGesture = opts.onUserGesture || (() => {});
+
+    /** @type {Set<string>} pressed KeyboardEvent.code values */
+    this.keys = new Set();
+    this.wasdMode = /** @type {'dpad'|'stick'} */ ('stick');
+
+    // Virtual gamepad overlay contribution (set by VirtualGamepad).
+    this.overlayState = { b: 0, l2: 0, r2: 0, lx: 0, ly: 0, rx: 0, ry: 0 };
+
+    // Mouse → touchpad plane.
+    this.tpPos = { x: TOUCHPAD_W / 2, y: TOUCHPAD_H / 2 };
+    this.tpTouchActive = false;
+    this.tpClickUntil = 0;
+    this._tpDown = null; // {t, moved}
+
+    this.gamepadSeen = false;
+    this._lastSentJson = '';
+    this._lastSentAt = 0;
+    this._timer = 0;
+    this._el = null;
+
+    this._onKeyDown = (e) => this._keyDown(e);
+    this._onKeyUp = (e) => this._keyUp(e);
+    this._onPadConn = () => this._refreshGamepadActive();
+    this._onPadDisc = () => this._refreshGamepadActive();
+  }
+
+  /** @param {HTMLElement} el — stream surface receiving pointer events */
+  attach(el) {
+    this._el = el;
+    window.addEventListener('keydown', this._onKeyDown);
+    window.addEventListener('keyup', this._onKeyUp);
+    window.addEventListener('gamepadconnected', this._onPadConn);
+    window.addEventListener('gamepaddisconnected', this._onPadDisc);
+
+    this._onPointerDown = (e) => this._pointerDown(e);
+    this._onPointerMove = (e) => this._pointerMove(e);
+    this._onPointerUp = (e) => this._pointerUp(e);
+    el.addEventListener('pointerdown', this._onPointerDown);
+    el.addEventListener('pointermove', this._onPointerMove);
+    el.addEventListener('pointerup', this._onPointerUp);
+    el.addEventListener('pointercancel', this._onPointerUp);
+
+    this._refreshGamepadActive();
+    this._timer = setInterval(() => this._tick(), 16);
+  }
+
+  detach() {
+    clearInterval(this._timer);
+    window.removeEventListener('keydown', this._onKeyDown);
+    window.removeEventListener('keyup', this._onKeyUp);
+    window.removeEventListener('gamepadconnected', this._onPadConn);
+    window.removeEventListener('gamepaddisconnected', this._onPadDisc);
+    if (this._el) {
+      this._el.removeEventListener('pointerdown', this._onPointerDown);
+      this._el.removeEventListener('pointermove', this._onPointerMove);
+      this._el.removeEventListener('pointerup', this._onPointerUp);
+      this._el.removeEventListener('pointercancel', this._onPointerUp);
+      this._el = null;
+    }
+    this.keys.clear();
+  }
+
+  /* ── keyboard ── */
+
+  _keyDown(e) {
+    this.onUserGesture();
+    if (e.code === 'Escape') {
+      e.preventDefault();
+      this.onMenu();
+      return;
+    }
+    if (e.code === 'F1' || (e.key === '?' && !e.repeat)) {
+      e.preventDefault();
+      this.onToggleHelp();
+      return;
+    }
+    if (e.code === 'F2') {
+      e.preventDefault();
+      this.wasdMode = this.wasdMode === 'dpad' ? 'stick' : 'dpad';
+      return;
+    }
+    if (this._isMapped(e.code)) {
+      e.preventDefault();
+      this.keys.add(e.code);
+    }
+  }
+
+  _keyUp(e) {
+    if (this._isMapped(e.code)) {
+      e.preventDefault();
+      this.keys.delete(e.code);
+    }
+  }
+
+  _isMapped(code) {
+    if (/^(Arrow(Up|Down|Left|Right)|Key[WASDIJKL]|Space|Enter|Backspace|Tab)$/.test(code)) {
+      return true;
+    }
+    return KEY_MAP.some((m) => m.keys.includes(code));
+  }
+
+  _keyboardState() {
+    const st = { b: 0, l2: 0, r2: 0, lx: 0, ly: 0, rx: 0, ry: 0 };
+    for (const m of KEY_MAP) {
+      if (!m.keys.some((k) => this.keys.has(k))) continue;
+      if (m.btn) st.b |= m.btn;
+      else if (m.trigger) st[m.trigger] = 255;
+    }
+    // WASD: left stick by default, d-pad after F2.
+    const w = this.keys.has('KeyW');
+    const a = this.keys.has('KeyA');
+    const s = this.keys.has('KeyS');
+    const d = this.keys.has('KeyD');
+    if (this.wasdMode === 'stick') {
+      if (a !== d) st.lx = d ? STICK_MAX : -STICK_MAX;
+      if (w !== s) st.ly = s ? STICK_MAX : -STICK_MAX; // positive = down
+    } else {
+      if (w) st.b |= BTN.DPAD_UP;
+      if (s) st.b |= BTN.DPAD_DOWN;
+      if (a) st.b |= BTN.DPAD_LEFT;
+      if (d) st.b |= BTN.DPAD_RIGHT;
+    }
+    // IJKL: right stick.
+    const i = this.keys.has('KeyI');
+    const j = this.keys.has('KeyJ');
+    const k = this.keys.has('KeyK');
+    const l = this.keys.has('KeyL');
+    if (j !== l) st.rx = l ? STICK_MAX : -STICK_MAX;
+    if (i !== k) st.ry = k ? STICK_MAX : -STICK_MAX;
+    return st;
+  }
+
+  /* ── mouse → touchpad plane ── */
+  //
+  // Desktop mouse clicks/drags deliberately do NOT emulate the DualShock
+  // touchpad: almost no games use it, and the emulation made every click on the
+  // video an accidental touchpad press/drag. Pointer handlers now only unlock
+  // the audio gesture; the touchpad is still reachable via the 'G' key and the
+  // on-screen PAD button in the touch overlay.
+
+  _pointerDown(e) {
+    this.onUserGesture();
+  }
+
+  _pointerMove(e) {}
+
+  _pointerUp(e) {}
+
+  /* ── gamepad ── */
+
+  _refreshGamepadActive() {
+    const active = this._anyStandardPad() !== null;
+    if (active !== this.gamepadSeen) {
+      this.gamepadSeen = active;
+      this.onGamepadActive(active);
+    }
+  }
+
+  _anyStandardPad() {
+    if (!navigator.getGamepads) return null;
+    for (const gp of navigator.getGamepads()) {
+      if (gp && gp.connected && gp.mapping === 'standard') return gp;
+    }
+    return null;
+  }
+
+  _gamepadState() {
+    const st = { b: 0, l2: 0, r2: 0, lx: 0, ly: 0, rx: 0, ry: 0 };
+    const gp = this._anyStandardPad();
+    if (!gp) return st;
+    for (const idx in GAMEPAD_MAP) {
+      const btn = gp.buttons[idx];
+      if (btn && btn.pressed) st.b |= GAMEPAD_MAP[idx];
+    }
+    st.l2 = gp.buttons[6] ? Math.round(gp.buttons[6].value * 255) : 0;
+    st.r2 = gp.buttons[7] ? Math.round(gp.buttons[7].value * 255) : 0;
+    st.lx = axisToI16(gp.axes[0] || 0);
+    st.ly = axisToI16(gp.axes[1] || 0); // positive = down (chiaki convention)
+    st.rx = axisToI16(gp.axes[2] || 0);
+    st.ry = axisToI16(gp.axes[3] || 0);
+    return st;
+  }
+
+  /* ── merge + send ── */
+
+  _tick() {
+    // Poll-driven refresh also catches pads that never fire connect events.
+    this._refreshGamepadActive();
+
+    const kb = this._keyboardState();
+    const gp = this._gamepadState();
+    const ov = this.overlayState;
+
+    const state = {
+      t: 'cs',
+      b: (kb.b | gp.b | ov.b) >>> 0,
+      l2: Math.max(kb.l2, gp.l2, ov.l2 | 0),
+      r2: Math.max(kb.r2, gp.r2, ov.r2 | 0),
+      lx: domAxis(domAxis(kb.lx, gp.lx), ov.lx | 0),
+      ly: domAxis(domAxis(kb.ly, gp.ly), ov.ly | 0),
+      rx: domAxis(domAxis(kb.rx, gp.rx), ov.rx | 0),
+      ry: domAxis(domAxis(kb.ry, gp.ry), ov.ry | 0),
+    };
+
+    if (performance.now() < this.tpClickUntil) state.b |= BTN.TOUCHPAD;
+    if (this.tpTouchActive) {
+      state.tp = [[0, Math.round(this.tpPos.x), Math.round(this.tpPos.y)]];
+    }
+
+    const json = JSON.stringify(state);
+    const now = performance.now();
+    if (json !== this._lastSentJson || now - this._lastSentAt >= 200) {
+      this._lastSentJson = json;
+      this._lastSentAt = now;
+      this.send(state);
+    }
+  }
+
+  /**
+   * Bridge rumble → Gamepad vibration.
+   * @param {{l?: number, r?: number}} msg — 0..255 per motor
+   */
+  rumble(msg) {
+    const gp = this._anyStandardPad();
+    if (!gp || !gp.vibrationActuator) return;
+    try {
+      gp.vibrationActuator.playEffect('dual-rumble', {
+        duration: 200,
+        strongMagnitude: Math.min(1, (msg.l || 0) / 255),
+        weakMagnitude: Math.min(1, (msg.r || 0) / 255),
+      });
+    } catch (e) {
+      /* actuator type unsupported */
+    }
+  }
+}

--- a/webbridge/frontend/js/mic-worklet.js
+++ b/webbridge/frontend/js/mic-worklet.js
@@ -1,0 +1,76 @@
+/**
+ * mic-worklet.js — AudioWorkletProcessor for microphone capture.
+ *
+ * Downmixes to mono, resamples to 48 kHz if the context runs at another rate
+ * (linear interpolation — fine for voice), converts to s16le, and posts one
+ * 480-sample (10 ms) Int16Array buffer at a time. The chunk size matches the
+ * frame the bridge's Opus encoder needs, so no re-framing happens later.
+ */
+
+const TARGET_RATE = 48000;
+const FRAME_SAMPLES = 480;
+
+class MicProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.ratio = sampleRate / TARGET_RATE; // input samples per output sample
+    this.pos = 0; // fractional read position into the stream, in input samples
+    this.tail = new Float32Array(0); // unconsumed input
+    this.out = new Int16Array(FRAME_SAMPLES);
+    this.outLen = 0;
+    this.muted = false;
+    this.port.onmessage = (e) => {
+      if (e.data && e.data.type === 'mute') this.muted = !!e.data.muted;
+    };
+  }
+
+  /**
+   * @param {Float32Array[][]} inputs
+   */
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || input.length === 0 || this.muted) return true;
+
+    // Downmix all capture channels to mono.
+    const ch0 = input[0];
+    let mono = ch0;
+    if (input.length > 1) {
+      mono = new Float32Array(ch0.length);
+      for (let c = 0; c < input.length; c++) {
+        const ch = input[c];
+        for (let i = 0; i < ch.length; i++) mono[i] += ch[i];
+      }
+      for (let i = 0; i < mono.length; i++) mono[i] /= input.length;
+    }
+
+    // Append to the unconsumed tail.
+    const buf = new Float32Array(this.tail.length + mono.length);
+    buf.set(this.tail, 0);
+    buf.set(mono, this.tail.length);
+
+    // Consume at `ratio` input samples per output sample.
+    let p = this.pos;
+    while (p + this.ratio < buf.length) {
+      const i0 = Math.floor(p);
+      const frac = p - i0;
+      const s = buf[i0] * (1 - frac) + buf[i0 + 1] * frac;
+      const v = Math.max(-1, Math.min(1, s));
+      this.out[this.outLen++] = (v * 32767) | 0;
+      if (this.outLen === FRAME_SAMPLES) {
+        // Transfer a copy; keep our working buffer.
+        const chunk = this.out.slice();
+        this.port.postMessage({ type: 'pcm', buf: chunk.buffer }, [chunk.buffer]);
+        this.outLen = 0;
+      }
+      p += this.ratio;
+    }
+
+    // Keep only what's not consumed yet.
+    const keepFrom = Math.floor(p);
+    this.tail = buf.slice(keepFrom);
+    this.pos = p - keepFrom;
+    return true;
+  }
+}
+
+registerProcessor('mic-processor', MicProcessor);

--- a/webbridge/frontend/js/mic.js
+++ b/webbridge/frontend/js/mic.js
@@ -1,0 +1,94 @@
+/**
+ * mic.js — microphone capture for voice chat.
+ *
+ * getUserMedia → AudioWorklet (mono, 48 kHz s16le, 480-sample chunks) →
+ * mic DataChannel. The bridge feeds the PCM into libchiaki's Opus encoder,
+ * which produces the exact frames the console requires.
+ */
+
+export class MicCapture {
+  /**
+   * @param {{ send: (buf: ArrayBuffer) => boolean,
+   *           log: (msg: string) => void }} cbs
+   */
+  constructor(cbs) {
+    this.cbs = cbs;
+    this.active = false;
+    /** @type {MediaStream|null} */ this.stream = null;
+    /** @type {AudioContext|null} */ this.ctx = null;
+    /** @type {AudioWorkletNode|null} */ this.node = null;
+  }
+
+  /** @returns {boolean} whether capture is running */
+  get running() {
+    return this.active;
+  }
+
+  /**
+   * Ask for the mic and start streaming PCM. Must be called from a user
+   * gesture on iOS. Throws with a user-presentable message on failure.
+   */
+  async start() {
+    if (this.active) return;
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+      throw new Error('Microphone capture not available (needs HTTPS)');
+    }
+    try {
+      this.stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+          channelCount: 1,
+        },
+      });
+    } catch (e) {
+      throw new Error('Microphone permission denied (' + (e && e.name) + ')');
+    }
+
+    try {
+      // Ask for 48 kHz; if the engine refuses, the worklet resamples.
+      try {
+        this.ctx = new AudioContext({ sampleRate: 48000 });
+      } catch (e) {
+        this.ctx = new AudioContext();
+      }
+      if (this.ctx.state === 'suspended') await this.ctx.resume();
+      await this.ctx.audioWorklet.addModule(new URL('./mic-worklet.js', import.meta.url));
+      const src = this.ctx.createMediaStreamSource(this.stream);
+      this.node = new AudioWorkletNode(this.ctx, 'mic-processor', {
+        numberOfInputs: 1,
+        numberOfOutputs: 0,
+      });
+      this.node.port.onmessage = (e) => {
+        if (e.data && e.data.type === 'pcm') this.cbs.send(e.data.buf);
+      };
+      src.connect(this.node);
+      this.active = true;
+      this.cbs.log('[mic] capture started (ctx rate ' + this.ctx.sampleRate + ')');
+    } catch (e) {
+      this.stop();
+      throw new Error('Microphone pipeline failed: ' + (e && e.message));
+    }
+  }
+
+  stop() {
+    this.active = false;
+    if (this.node) {
+      try {
+        this.node.port.postMessage({ type: 'mute', muted: true });
+        this.node.disconnect();
+      } catch (e) { /* already gone */ }
+      this.node = null;
+    }
+    if (this.ctx) {
+      this.ctx.close().catch(() => {});
+      this.ctx = null;
+    }
+    if (this.stream) {
+      for (const t of this.stream.getTracks()) t.stop();
+      this.stream = null;
+    }
+    this.cbs.log('[mic] capture stopped');
+  }
+}

--- a/webbridge/frontend/js/pcm-player-worklet.js
+++ b/webbridge/frontend/js/pcm-player-worklet.js
@@ -1,0 +1,124 @@
+/**
+ * pcm-player-worklet.js — jitter-buffered PCM playback for the WebSocket
+ * transport (there is no RTP track to lean on, so buffering/concealment that
+ * the browser normally does for WebRTC audio happens here).
+ *
+ * Receives interleaved s16le Int16Array chunks (any length) via port messages:
+ *   { pcm: Int16Array }                      — audio data
+ *   { config: { rate, channels } }           — source format (before first pcm)
+ *
+ * Policy: hold START_S of audio before starting (and after every underrun),
+ * and if the queue grows past MAX_S (slow tab, TCP burst after stall) drop
+ * down to TARGET_S so latency cannot creep up permanently.
+ */
+
+const START_S = 0.08;
+const TARGET_S = 0.12;
+const MAX_S = 0.45;
+
+class PcmPlayerProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.inRate = 48000;
+    this.channels = 2;
+    /** @type {Float32Array[][]} deinterleaved, resampled chunks */
+    this.queue = [];
+    this.queued = 0; // frames currently queued
+    this.readOff = 0; // frames consumed from queue[0]
+    this.playing = false;
+    this._resampPos = 0;
+    /** @type {Float32Array[]|null} last frame of previous chunk (resampler seam) */
+    this._tail = null;
+
+    this.port.onmessage = (e) => {
+      const m = e.data;
+      if (m.config) {
+        this.inRate = m.config.rate || 48000;
+        this.channels = m.config.channels || 2;
+        return;
+      }
+      if (m.pcm) this._push(m.pcm);
+    };
+  }
+
+  /** @param {Int16Array} pcm interleaved s16 */
+  _push(pcm) {
+    const ch = this.channels;
+    const inFrames = Math.floor(pcm.length / ch);
+    if (inFrames === 0) return;
+
+    const ratio = this.inRate / sampleRate;
+    const outFrames = ratio === 1 ? inFrames : Math.max(1, Math.round(inFrames / ratio));
+    const out = [];
+    for (let c = 0; c < ch; c++) out.push(new Float32Array(outFrames));
+
+    if (ratio === 1) {
+      for (let i = 0; i < inFrames; i++) {
+        for (let c = 0; c < ch; c++) out[c][i] = pcm[i * ch + c] / 32768;
+      }
+    } else {
+      // Linear resample; good enough for a fallback voice/game-audio path.
+      for (let i = 0; i < outFrames; i++) {
+        const pos = i * ratio;
+        const i0 = Math.min(inFrames - 1, Math.floor(pos));
+        const i1 = Math.min(inFrames - 1, i0 + 1);
+        const frac = pos - i0;
+        for (let c = 0; c < ch; c++) {
+          const a = pcm[i0 * ch + c] / 32768;
+          const b = pcm[i1 * ch + c] / 32768;
+          out[c][i] = a + (b - a) * frac;
+        }
+      }
+    }
+
+    this.queue.push(out);
+    this.queued += outFrames;
+
+    // Latency cap: shed oldest audio down to TARGET_S.
+    const maxFrames = MAX_S * sampleRate;
+    if (this.queued > maxFrames) {
+      const targetFrames = TARGET_S * sampleRate;
+      while (this.queued - (this.queue[0][0].length - this.readOff) > targetFrames && this.queue.length > 1) {
+        this.queued -= this.queue[0][0].length - this.readOff;
+        this.queue.shift();
+        this.readOff = 0;
+      }
+    }
+  }
+
+  process(inputs, outputs) {
+    const out = outputs[0];
+    const frames = out[0].length;
+    const outCh = out.length;
+
+    if (!this.playing) {
+      if (this.queued < START_S * sampleRate) return true; // silence
+      this.playing = true;
+    }
+    if (this.queued === 0) {
+      this.playing = false; // underrun: rebuffer
+      return true;
+    }
+
+    let written = 0;
+    while (written < frames && this.queue.length > 0) {
+      const chunk = this.queue[0];
+      const avail = chunk[0].length - this.readOff;
+      const n = Math.min(avail, frames - written);
+      for (let c = 0; c < outCh; c++) {
+        const src = chunk[Math.min(c, this.channels - 1)];
+        out[c].set(src.subarray(this.readOff, this.readOff + n), written);
+      }
+      written += n;
+      this.readOff += n;
+      this.queued -= n;
+      if (this.readOff >= chunk[0].length) {
+        this.queue.shift();
+        this.readOff = 0;
+      }
+    }
+    return true;
+  }
+}
+
+registerProcessor('pcm-player', PcmPlayerProcessor);

--- a/webbridge/frontend/js/signaling.js
+++ b/webbridge/frontend/js/signaling.js
@@ -1,0 +1,236 @@
+/**
+ * signaling.js — WebSocket signaling client for the chiaki-web bridge.
+ *
+ * Wire format: JSON text messages, per webbridge/PROTOCOL.md.
+ * The client sends `start` / `answer` / `candidate` / `stop`; the bridge sends
+ * `streamInfo` / `offer` / `candidate` / `status` / `quit`.
+ */
+
+/**
+ * Build the signaling WebSocket URL.
+ *
+ * PROTOCOL.md: when the page is served through a path-preserving reverse
+ * proxy (path contains `/lp/<port>/`), substitute the port segment of our own
+ * URL instead of using `location.port`. Otherwise connect straight to
+ * `ws(s)://<hostname>:<wsPort>/`.
+ *
+ * @param {number} wsPort — signaling port from GET /api/info
+ * @returns {string}
+ */
+export function buildWsUrl(wsPort) {
+  const scheme = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const m = location.pathname.match(/^(.*\/lp\/)\d+(\/|$)/);
+  if (m) {
+    return `${scheme}//${location.host}${m[1]}${wsPort}/`;
+  }
+  // Dedicated hostname on standard ports (tunnel/reverse proxy): the fronting
+  // proxy routes the same-origin /ws path to the signaling port.
+  if (!location.port || location.port === '443' || location.port === '80') {
+    return `${scheme}//${location.host}/ws`;
+  }
+  return `${scheme}//${location.hostname}:${wsPort}/`;
+}
+
+/**
+ * REST base path. Relative fetches already resolve correctly under the
+ * `/lp/<port>/` proxy prefix as long as the page URL ends with a slash (or a
+ * file name); this normalizes the directory part so `api(...)` always works.
+ * @returns {string} base path ending with '/'
+ */
+export function apiBase() {
+  const p = location.pathname;
+  return p.endsWith('/') ? p : p.slice(0, p.lastIndexOf('/') + 1);
+}
+
+/** @param {string} path e.g. 'api/hosts' */
+export function apiUrl(path) {
+  return apiBase() + path;
+}
+
+/* ── optional shared-secret gate (CHIAKI_WEB_TOKEN on the bridge) ────────── */
+
+const TOKEN_KEY = 'cw-token';
+
+export function getToken() {
+  try {
+    return localStorage.getItem(TOKEN_KEY) || '';
+  } catch {
+    return '';
+  }
+}
+
+export function setToken(t) {
+  try {
+    localStorage.setItem(TOKEN_KEY, t);
+  } catch { /* private browsing */ }
+}
+
+/**
+ * fetch() wrapper that sends the access token and, on 401, prompts for one
+ * once and retries.
+ * @param {string} path @param {RequestInit} [opts]
+ */
+export async function api(path, opts = {}) {
+  const headers = { ...(opts.headers || {}) };
+  const tok = getToken();
+  if (tok) headers['X-Auth-Token'] = tok;
+  let res = await fetch(apiUrl(path), { ...opts, headers });
+  if (res.status === 401) {
+    const entered = window.prompt('This bridge requires an access token:');
+    if (entered && entered.trim()) {
+      setToken(entered.trim());
+      headers['X-Auth-Token'] = entered.trim();
+      res = await fetch(apiUrl(path), { ...opts, headers });
+    }
+  }
+  return res;
+}
+
+export class Signaling {
+  /** @param {number} wsPort */
+  constructor(wsPort) {
+    this.url = buildWsUrl(wsPort);
+    /** @type {WebSocket|null} */
+    this.ws = null;
+    /** @type {(msg: object) => void} */
+    this.onmessage = () => {};
+    /** @type {(buf: ArrayBuffer) => void} ws-transport media (channel-prefixed) */
+    this.onbinary = () => {};
+    /** @type {(clean: boolean) => void} */
+    this.onclose = () => {};
+    this._closedByUs = false;
+  }
+
+  /** Open the socket. Resolves once connected. @returns {Promise<void>} */
+  connect() {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const ws = new WebSocket(this.url);
+      ws.binaryType = 'arraybuffer';
+      this.ws = ws;
+      ws.onopen = () => {
+        settled = true;
+        resolve();
+      };
+      ws.onerror = () => {
+        if (!settled) {
+          settled = true;
+          reject(new Error('signaling connection failed (' + this.url + ')'));
+        }
+      };
+      ws.onclose = () => {
+        if (!settled) {
+          settled = true;
+          reject(new Error('signaling connection closed'));
+          return;
+        }
+        this.onclose(this._closedByUs);
+      };
+      ws.onmessage = (ev) => {
+        if (ev.data instanceof ArrayBuffer) {
+          this.onbinary(ev.data);
+          return;
+        }
+        if (typeof ev.data !== 'string') return;
+        let msg;
+        try {
+          msg = JSON.parse(ev.data);
+        } catch (e) {
+          console.warn('[signaling] non-JSON message ignored');
+          return;
+        }
+        if (msg && typeof msg === 'object') this.onmessage(msg);
+      };
+    });
+  }
+
+  /** @param {object} msg */
+  send(msg) {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(msg));
+    }
+  }
+
+  /** ws-transport upstream media (channel-prefixed). @param {ArrayBuffer|Uint8Array} buf */
+  sendBinary(buf) {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      try {
+        this.ws.send(buf);
+        return true;
+      } catch { /* closing */ }
+    }
+    return false;
+  }
+
+  /** Ask the bridge to swap the media path mid-session. @param {'ws'} transport */
+  switchTransport(transport) {
+    this.send({ type: 'switchTransport', transport });
+  }
+
+  /**
+   * Ask the bridge to start a session.
+   * @param {{host?: string, demo?: boolean, resolution?: string,
+   *          fps?: number, codec?: string, bitrate?: number}} opts
+   */
+  start(opts) {
+    const token = getToken();
+    this.send(token ? { type: 'start', token, ...opts } : { type: 'start', ...opts });
+  }
+
+  /** Send our SDP answer. @param {string} sdp */
+  answer(sdp) {
+    this.send({ type: 'answer', sdp });
+  }
+
+  /**
+   * Trickle a local ICE candidate to the bridge.
+   * @param {string} candidate @param {string} mid
+   */
+  candidate(candidate, mid) {
+    this.send({ type: 'candidate', candidate, mid });
+  }
+
+  /**
+   * Remote diagnostics: forward a client-side event to the bridge log.
+   * Rate-limited and truncated; silently dropped when the WS is closed.
+   * @param {string} msg
+   */
+  log(msg) {
+    const text = String(msg);
+    // Mirror to the browser devtools console so it's visible client-side too,
+    // not only in the bridge log. Not rate-limited locally.
+    try {
+      // eslint-disable-next-line no-console
+      console.log('[chiaki-web] ' + text);
+    } catch { /* console unavailable */ }
+
+    const tick = (Date.now() / 1000) | 0;
+    if (tick !== this._logTick) {
+      this._logTick = tick;
+      this._logCount = 0;
+    }
+    if (++this._logCount > 20) return; // cap on what we ship upstream: 20 lines/s
+    try {
+      this.send({ type: 'clientlog', msg: text.slice(0, 600) });
+    } catch { /* never let diagnostics break the session */ }
+  }
+
+  /** Politely end the session, then close the socket. */
+  stop() {
+    this._closedByUs = true;
+    this.send({ type: 'stop' });
+    this.close();
+  }
+
+  close() {
+    this._closedByUs = true;
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch (e) {
+        /* already closed */
+      }
+      this.ws = null;
+    }
+  }
+}

--- a/webbridge/frontend/js/ui.js
+++ b/webbridge/frontend/js/ui.js
@@ -1,0 +1,137 @@
+/**
+ * ui.js — small UI helpers: toasts, modal handling, HUD text, help overlay.
+ */
+
+/**
+ * Show a transient toast at the bottom of the screen.
+ * @param {string} text
+ * @param {'info'|'error'} [kind]
+ */
+export function toast(text, kind = 'info') {
+  const host = document.getElementById('toasts');
+  if (!host) return;
+  const node = document.createElement('div');
+  node.className = 'toast' + (kind === 'error' ? ' toast-error' : '');
+  node.textContent = text;
+  host.appendChild(node);
+  setTimeout(() => node.classList.add('toast-show'), 10);
+  setTimeout(() => {
+    node.classList.remove('toast-show');
+    setTimeout(() => node.remove(), 300);
+  }, 4200);
+}
+
+/**
+ * Open a modal by element. Returns a close function. Clicking the backdrop
+ * closes unless opts.sticky.
+ * @param {HTMLElement} modal @param {{sticky?: boolean, onClose?: () => void}} [opts]
+ */
+export function openModal(modal, opts = {}) {
+  modal.classList.add('modal-open');
+  const close = () => {
+    modal.classList.remove('modal-open');
+    modal.removeEventListener('click', onBackdrop);
+    if (opts.onClose) opts.onClose();
+  };
+  const onBackdrop = (e) => {
+    if (e.target === modal && !opts.sticky) close();
+  };
+  modal.addEventListener('click', onBackdrop);
+  return close;
+}
+
+/**
+ * Stream HUD: shows nickname / stream parameters / live stats.
+ */
+export class Hud {
+  constructor() {
+    this.el = document.getElementById('hud-stats');
+    this.nickEl = document.getElementById('hud-nickname');
+    this.infoEl = document.getElementById('hud-streaminfo');
+    this.visible = false;
+    this._bitrateBytes = 0;
+    this._bitrateAt = 0;
+    this._bitrateKbps = 0;
+  }
+
+  setNickname(name) {
+    if (this.nickEl) this.nickEl.textContent = name || '';
+  }
+
+  /** @param {{codec: string, width: number, height: number, fps: number}} info */
+  setStreamInfo(info) {
+    if (this.infoEl) {
+      this.infoEl.textContent = `${info.codec} ${info.width}×${info.height}@${info.fps}`;
+    }
+  }
+
+  /** Feed a cumulative byte counter; the HUD derives kbps. */
+  noteBytes(bytes) {
+    const now = performance.now();
+    if (this._bitrateAt > 0 && now > this._bitrateAt) {
+      const dt = (now - this._bitrateAt) / 1000;
+      if (dt > 0.2) {
+        this._bitrateKbps = ((bytes - this._bitrateBytes) * 8) / 1000 / dt;
+        this._bitrateBytes = bytes;
+        this._bitrateAt = now;
+      }
+    } else {
+      this._bitrateBytes = bytes;
+      this._bitrateAt = now;
+    }
+  }
+
+  /** @param {object} s — worker stats message */
+  update(s) {
+    if (!this.el || !this.visible) return;
+    const lines = [
+      `fps      ${s.fps.toFixed(1)}`,
+      `bitrate  ${(this._bitrateKbps / 1000).toFixed(1)} Mbps`,
+      `decodeQ  ${s.decodeQueue}  renderQ ${s.renderQueue}`,
+      `holdback ${s.holdbackMs} ms`,
+      `frames   ${s.rendered} drawn / ${s.dropped} dropped`,
+    ];
+    this.el.textContent = lines.join('\n');
+  }
+
+  toggle() {
+    this.visible = !this.visible;
+    if (this.el) this.el.classList.toggle('hidden', !this.visible);
+    return this.visible;
+  }
+
+  hideStats() {
+    this.visible = false;
+    if (this.el) this.el.classList.add('hidden');
+  }
+}
+
+/** Fill the keyboard-help table from the input map. */
+export function renderKeyHelp(keyMap, extras) {
+  const tbody = document.getElementById('help-table');
+  if (!tbody) return;
+  tbody.textContent = '';
+  const row = (keysText, label) => {
+    const tr = document.createElement('tr');
+    const td1 = document.createElement('td');
+    const td2 = document.createElement('td');
+    td1.innerHTML = keysText
+      .split(' / ')
+      .map((k) => `<kbd>${k}</kbd>`)
+      .join(' ');
+    td2.textContent = label;
+    tr.append(td1, td2);
+    tbody.appendChild(tr);
+  };
+  for (const m of keyMap) {
+    const keys = m.keys
+      .map((k) => k
+        .replace(/^Key/, '')
+        .replace(/^Digit/, '')
+        .replace(/^Arrow/, '')
+        .replace(/^(Shift|Control|Alt)(Left|Right)$/, '$2 $1'))
+      .join(' / ');
+    row(keys, m.label);
+  }
+  for (const e of extras) row(e.keys, e.label);
+}

--- a/webbridge/frontend/js/video-worker.js
+++ b/webbridge/frontend/js/video-worker.js
@@ -1,0 +1,941 @@
+/**
+ * video-worker.js — VideoDecoder + OffscreenCanvas worker for chiaki-web.
+ *
+ * Receives complete Annex-B access units from the main thread (see video.js),
+ * derives decoder configuration from the in-band parameter sets, decodes with
+ * WebCodecs and paints frames onto the transferred OffscreenCanvas.
+ *
+ * Messages in:  {type:'init', canvas, codec}
+ *               {type:'frame', data:ArrayBuffer, keyframe:boolean, backendTs:number}
+ *               {type:'frameLoss'} — main saw a frameId gap
+ *               {type:'stop'}
+ * Messages out: {type:'requestIdr'} {type:'stats',...} {type:'firstFrame'}
+ *               {type:'fatal', msg}
+ */
+
+/* ────────────────────────── Annex-B / NAL helpers ───────────────────────── */
+
+const H264_NAL_SPS = 7;
+const H264_NAL_PPS = 8;
+const HEVC_NAL_VPS = 32;
+const HEVC_NAL_SPS = 33;
+const HEVC_NAL_PPS = 34;
+
+/**
+ * Split an Annex-B buffer into NAL units (start codes removed).
+ * Accepts both 3-byte and 4-byte start codes.
+ * @param {Uint8Array} buf
+ * @returns {Uint8Array[]}
+ */
+function splitNals(buf) {
+  /** @type {Uint8Array[]} */
+  const out = [];
+  const len = buf.length;
+  let i = 0;
+  let nalStart = -1;
+  while (i + 2 < len) {
+    if (buf[i] === 0 && buf[i + 1] === 0) {
+      let scLen = 0;
+      if (buf[i + 2] === 1) scLen = 3;
+      else if (i + 3 < len && buf[i + 2] === 0 && buf[i + 3] === 1) scLen = 4;
+      if (scLen) {
+        if (nalStart >= 0) out.push(buf.subarray(nalStart, i));
+        nalStart = i + scLen;
+        i += scLen;
+        continue;
+      }
+    }
+    i++;
+  }
+  if (nalStart >= 0 && nalStart < len) out.push(buf.subarray(nalStart, len));
+  return out;
+}
+
+/**
+ * Strip emulation-prevention bytes (00 00 03 → 00 00) from a NAL unit,
+ * returning a fresh Uint8Array.
+ * @param {Uint8Array} nal
+ */
+function deEmulate(nal) {
+  const out = new Uint8Array(nal.length);
+  let o = 0;
+  for (let i = 0; i < nal.length; i++) {
+    if (i >= 2 && nal[i] === 3 && nal[i - 1] === 0 && nal[i - 2] === 0) continue;
+    out[o++] = nal[i];
+  }
+  return out.subarray(0, o);
+}
+
+function h264NalType(nal) {
+  return nal.length ? nal[0] & 0x1f : -1;
+}
+function hevcNalType(nal) {
+  return nal.length >= 2 ? (nal[0] >> 1) & 0x3f : -1;
+}
+
+function bytesEqual(a, b) {
+  if (!a || !b || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/** Holds the current parameter sets and knows when configuration is possible. */
+class ParamSets {
+  /** @param {'h264'|'hevc'} codec */
+  constructor(codec) {
+    this.codec = codec;
+    /** @type {Uint8Array|null} */ this.sps = null;
+    /** @type {Uint8Array|null} */ this.pps = null;
+    /** @type {Uint8Array|null} */ this.vps = null;
+  }
+
+  ready() {
+    return this.codec === 'hevc' ? !!(this.vps && this.sps && this.pps) : !!(this.sps && this.pps);
+  }
+
+  /**
+   * Scan an AU for parameter sets.
+   * @param {Uint8Array[]} nals
+   * @returns {boolean} true if any parameter set CHANGED (or first appeared)
+   */
+  absorb(nals) {
+    let changed = false;
+    for (const n of nals) {
+      if (this.codec === 'hevc') {
+        const t = hevcNalType(n);
+        if (t === HEVC_NAL_VPS && !bytesEqual(this.vps, n)) {
+          this.vps = n.slice();
+          changed = true;
+        } else if (t === HEVC_NAL_SPS && !bytesEqual(this.sps, n)) {
+          this.sps = n.slice();
+          changed = true;
+        } else if (t === HEVC_NAL_PPS && !bytesEqual(this.pps, n)) {
+          this.pps = n.slice();
+          changed = true;
+        }
+      } else {
+        const t = h264NalType(n);
+        if (t === H264_NAL_SPS && !bytesEqual(this.sps, n)) {
+          this.sps = n.slice();
+          changed = true;
+        } else if (t === H264_NAL_PPS && !bytesEqual(this.pps, n)) {
+          this.pps = n.slice();
+          changed = true;
+        }
+      }
+    }
+    return changed;
+  }
+}
+
+/* ─────────────────── codec strings + description records ────────────────── */
+
+/** avc1.PPCCLL from the SPS profile/compat/level bytes. */
+function h264CodecString(sps) {
+  if (!sps || sps.length < 4) return 'avc1.64002a';
+  const hex = (b) => b.toString(16).padStart(2, '0');
+  return 'avc1.' + hex(sps[1]) + hex(sps[2]) + hex(sps[3]);
+}
+
+/** AVCDecoderConfigurationRecord (avcC) with one SPS and one PPS. */
+function buildAvcC(sps, pps) {
+  const out = new Uint8Array(11 + sps.length + pps.length);
+  let o = 0;
+  out[o++] = 1; // version
+  out[o++] = sps[1];
+  out[o++] = sps[2];
+  out[o++] = sps[3];
+  out[o++] = 0xff; // 4-byte NALU lengths
+  out[o++] = 0xe1; // one SPS
+  out[o++] = sps.length >> 8;
+  out[o++] = sps.length & 0xff;
+  out.set(sps, o);
+  o += sps.length;
+  out[o++] = 1; // one PPS
+  out[o++] = pps.length >> 8;
+  out[o++] = pps.length & 0xff;
+  out.set(pps, o);
+  return out;
+}
+
+/** MSB-first bit reader with unsigned Exp-Golomb, for SPS walking. */
+class BitReader {
+  constructor(bytes) {
+    this.b = bytes;
+    this.pos = 0;
+  }
+  u(n) {
+    let v = 0;
+    for (let i = 0; i < n; i++) {
+      const idx = this.pos >> 3;
+      if (idx >= this.b.length) throw new RangeError('bitstream overrun');
+      v = (v << 1) | ((this.b[idx] >> (7 - (this.pos & 7))) & 1);
+      this.pos++;
+    }
+    return v;
+  }
+  ue() {
+    let zeros = 0;
+    while (this.u(1) === 0) if (++zeros > 31) throw new RangeError('ue too long');
+    return zeros === 0 ? 0 : (1 << zeros) - 1 + this.u(zeros);
+  }
+}
+
+/**
+ * Walk a de-emulated HEVC SPS far enough to learn chroma format and bit
+ * depths (needed for a well-formed hvcC). Defaults to 4:2:0 8-bit on error.
+ * @param {Uint8Array} spsClean — de-emulated, includes 2-byte NAL header
+ */
+function hevcSpsFormatInfo(spsClean) {
+  const info = { chroma: 1, lumaMinus8: 0, chromaMinus8: 0 };
+  try {
+    const r = new BitReader(spsClean.subarray(2));
+    r.u(4); // vps id
+    const maxSub = r.u(3);
+    r.u(1); // temporal nesting
+    // profile_tier_level: 96 bits of general PTL
+    r.u(8); // profile_space/tier/profile_idc
+    r.u(32); // compatibility flags
+    r.u(32);
+    r.u(16); // 48 constraint bits
+    r.u(8); // level idc
+    const profPresent = [];
+    const lvlPresent = [];
+    for (let i = 0; i < maxSub; i++) {
+      profPresent.push(r.u(1));
+      lvlPresent.push(r.u(1));
+    }
+    if (maxSub > 0) for (let i = maxSub; i < 8; i++) r.u(2);
+    for (let i = 0; i < maxSub; i++) {
+      if (profPresent[i]) {
+        r.u(8);
+        r.u(32);
+        r.u(32);
+        r.u(16);
+      }
+      if (lvlPresent[i]) r.u(8);
+    }
+    r.ue(); // sps id
+    info.chroma = r.ue();
+    if (info.chroma === 3) r.u(1);
+    r.ue(); // width
+    r.ue(); // height
+    if (r.u(1)) {
+      r.ue();
+      r.ue();
+      r.ue();
+      r.ue(); // conformance window
+    }
+    info.lumaMinus8 = r.ue();
+    info.chromaMinus8 = r.ue();
+  } catch (e) {
+    /* keep defaults */
+  }
+  return info;
+}
+
+/**
+ * hvc1.P.C.Lxxx.B0 from the SPS profile-tier-level.
+ * @param {Uint8Array} sps — raw SPS NAL (may contain emulation bytes)
+ */
+function hevcCodecString(sps) {
+  if (!sps || sps.length < 6) return 'hvc1.1.6.L153.B0';
+  const rbsp = deEmulate(sps.subarray(2));
+  // rbsp[0]: sps header byte; rbsp[1]: profile_space/tier/profile_idc;
+  // rbsp[2..5]: profile compatibility flags; rbsp[6..11]: constraint flags;
+  // rbsp[12]: general_level_idc.
+  const profileIdc = rbsp.length > 1 ? rbsp[1] & 0x1f : 1;
+  const tier = rbsp.length > 1 && rbsp[1] & 0x20 ? 'H' : 'L';
+  // Compatibility field: the 32 compat flags in bit-reversed order, hex.
+  let compat = 6;
+  if (rbsp.length > 5) {
+    const flags =
+      ((rbsp[2] << 24) | (rbsp[3] << 16) | (rbsp[4] << 8) | rbsp[5]) >>> 0;
+    let rev = 0;
+    for (let i = 0; i < 32; i++) if (flags & (1 << i)) rev |= 1 << (31 - i);
+    compat = (rev >>> 0).toString(16);
+  }
+  let level = rbsp.length > 12 ? rbsp[12] : 153;
+  if (level < 30) level = 153; // implausible level → safe 5.1
+  return `hvc1.${profileIdc}.${compat}.${tier}${level}.B0`;
+}
+
+/**
+ * HEVCDecoderConfigurationRecord (hvcC).
+ *
+ * The PTL bytes come from the DE-EMULATED SPS (emulation bytes shift the
+ * fixed offsets), and the parameter-set arrays also carry de-emulated NALs:
+ * Chromium cross-checks the array SPS against the header PTL and rejects the
+ * config when raw emulation bytes make them disagree.
+ */
+function buildHvcC(vps, sps, pps) {
+  const v = deEmulate(vps);
+  const s = deEmulate(sps);
+  const p = deEmulate(pps);
+  if (s.length < 15) return null;
+  const fmt = hevcSpsFormatInfo(s);
+
+  const out = new Uint8Array(23 + 3 * 5 + v.length + s.length + p.length);
+  let o = 0;
+  out[o++] = 1; // version
+  out.set(s.subarray(3, 15), o); // 12 bytes general PTL
+  o += 12;
+  out[o++] = 0xf0; // min_spatial_segmentation (reserved bits set)
+  out[o++] = 0x00;
+  out[o++] = 0xfc; // parallelismType
+  out[o++] = 0xfc | (fmt.chroma & 3);
+  out[o++] = 0xf8 | (fmt.lumaMinus8 & 7);
+  out[o++] = 0xf8 | (fmt.chromaMinus8 & 7);
+  out[o++] = 0; // avgFrameRate
+  out[o++] = 0;
+  out[o++] = 0x0f; // 1 temporal layer, nested, 4-byte lengths
+  out[o++] = 3; // three arrays
+  for (const [type, nal] of [
+    [HEVC_NAL_VPS, v],
+    [HEVC_NAL_SPS, s],
+    [HEVC_NAL_PPS, p],
+  ]) {
+    out[o++] = type;
+    out[o++] = 0;
+    out[o++] = 1;
+    out[o++] = nal.length >> 8;
+    out[o++] = nal.length & 0xff;
+    out.set(nal, o);
+    o += nal.length;
+  }
+  return out;
+}
+
+const H264_CODEC_FALLBACKS = [
+  'avc1.64002a', // High 4.2
+  'avc1.640028',
+  'avc1.64001f',
+  'avc1.4d002a', // Main 4.2
+  'avc1.4d0028',
+  'avc1.42e02a', // Constrained Baseline 4.2
+  'avc1.42e01e',
+];
+
+const HEVC_AVCC_FALLBACKS = [
+  'hvc1.1.6.L153.B0', // Main, level 5.1 — typical 1080p60
+  'hvc1.1.6.L150.B0',
+  'hvc1.1.6.L123.B0',
+  'hvc1.1.6.L120.B0',
+  'hvc1.1.2.L153.B0',
+  'hvc1.2.4.L153.B0', // Main10
+];
+
+const SDR_COLOR = {
+  colorSpace: { primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: false },
+};
+
+/* ───────────────────── chunk packaging (Annex-B / AVCC) ──────────────────── */
+
+/**
+ * Repackage an AU for the decoder.
+ *
+ * annexB mode: 4-byte start codes, all NALs kept (Chromium's Annex-B keyframe
+ * analyzer needs the parameter sets in-band).
+ * AVCC mode: 4-byte big-endian length prefixes, parameter sets stripped (they
+ * live in the description) and, for HEVC, leading non-IRAP NALs dropped so
+ * the first NAL is an IRAP (Chromium validates this).
+ *
+ * @param {Uint8Array} au @param {'h264'|'hevc'} codec @param {boolean} annexB
+ */
+function packageAu(au, codec, annexB) {
+  const nals = splitNals(au);
+  /** @type {Uint8Array[]} */
+  const keep = [];
+  let total = 0;
+  let sawIrap = false;
+  for (const n of nals) {
+    if (n.length === 0) continue;
+    if (!annexB) {
+      if (codec === 'hevc') {
+        const t = hevcNalType(n);
+        if (t === HEVC_NAL_VPS || t === HEVC_NAL_SPS || t === HEVC_NAL_PPS) continue;
+        if (!sawIrap) {
+          if (t >= 16 && t <= 21) sawIrap = true;
+          else if (t >= 32) continue; // SEI/other non-VCL before the IRAP
+        }
+      } else {
+        const t = h264NalType(n);
+        if (t === H264_NAL_SPS || t === H264_NAL_PPS) continue;
+      }
+    }
+    keep.push(n);
+    total += 4 + n.length;
+  }
+  const out = new Uint8Array(total);
+  let o = 0;
+  for (const n of keep) {
+    if (annexB) {
+      out[o + 3] = 1; // 00 00 00 01
+    } else {
+      out[o] = n.length >>> 24;
+      out[o + 1] = (n.length >>> 16) & 0xff;
+      out[o + 2] = (n.length >>> 8) & 0xff;
+      out[o + 3] = n.length & 0xff;
+    }
+    out.set(n, o + 4);
+    o += 4 + n.length;
+  }
+  return out;
+}
+
+/* ─────────────────────────────── pacer ──────────────────────────────────── */
+
+/**
+ * HoldbackPacer — minimal presentation reserve keyed off backendTs.
+ *
+ * Transit delay = now - backendTs (two unrelated clocks, so only variation
+ * matters). The minimum delay seen recently is the baseline; each frame's
+ * excess over the baseline samples the jitter. The reserve targets the p95 of
+ * that excess (clamped to 0..MAX) and each frame is held for whatever part of
+ * the reserve it has not already spent in flight. Same shape as a full
+ * FramePacer, so one can drop in behind schedule()/reset() later.
+ */
+class HoldbackPacer {
+  constructor() {
+    this.MAX = 25; // ms — cap; beyond this latency hurts more than judder
+    this.WINDOW_MS = 2000;
+    this.DEADBAND = 3; // ms — snap tiny reserves to zero
+    this.RESYNC = 500; // ms — discontinuity → rebase
+    this.reset();
+  }
+
+  reset() {
+    this.primed = false;
+    this.baseline = 0;
+    this.target = 0;
+    /** @type {{t:number, ex:number}[]} */
+    this.samples = [];
+    this.lastControl = 0;
+  }
+
+  /**
+   * @param {number} backendTs — sender clock ms (0 = unknown → no hold)
+   * @param {number} now — performance.now()
+   * @returns {number} presentation deadline in the local clock
+   */
+  schedule(backendTs, now) {
+    if (!(backendTs > 0)) return now;
+    const delay = now - backendTs;
+    if (!this.primed || Math.abs(delay - this.baseline) > this.RESYNC) {
+      this.primed = true;
+      this.baseline = delay;
+      this.samples.length = 0;
+      this.target = 0;
+      return now;
+    }
+    // Baseline follows the best path down instantly, up only slowly.
+    this.baseline = Math.min(delay, this.baseline + 0.05);
+    const excess = delay - this.baseline;
+    this.samples.push({ t: now, ex: excess });
+    const cutoff = now - this.WINDOW_MS;
+    while (this.samples.length && this.samples[0].t < cutoff) this.samples.shift();
+    if (this.samples.length > 256) this.samples.splice(0, this.samples.length - 256);
+
+    if (now - this.lastControl > 100) {
+      this.lastControl = now;
+      const sorted = this.samples.map((x) => x.ex).sort((a, b) => a - b);
+      const p95 = sorted.length ? sorted[Math.min(sorted.length - 1, (sorted.length * 0.95) | 0)] : 0;
+      let t = Math.min(this.MAX, p95 * 1.15);
+      if (t < this.DEADBAND) t = 0;
+      // Rise immediately, fall gently.
+      this.target = t > this.target ? t : Math.max(t, this.target - 1);
+    }
+    const wait = this.target - excess;
+    return wait > 2 ? now + wait : now;
+  }
+}
+
+/* ───────────────────────────── worker state ─────────────────────────────── */
+
+const W = {
+  /** @type {OffscreenCanvas|null} */ canvas: null,
+  /** @type {(OffscreenCanvasRenderingContext2D|null)} */ ctx: null,
+  /** @type {'h264'|'hevc'} */ codec: 'h264',
+  /** @type {VideoDecoder|null} */ decoder: null,
+  /** @type {ParamSets|null} */ params: null,
+  configured: false,
+  configuring: false,
+  annexBMode: false,
+
+  /** @type {{data:Uint8Array, keyframe:boolean, backendTs:number}[]} */
+  pendingAus: [],
+  /** @type {{frame:VideoFrame, presentAt:number}[]} */
+  renderQueue: [],
+  pacer: new HoldbackPacer(),
+  renderLoopArmed: false,
+
+  referenceValid: true,
+  recoveryAttempts: 0,
+  stopped: false,
+  firstFrameSent: false,
+  queueStallSince: 0,
+  frameSeq: 0,
+  lastChunkTs: 0,
+
+  stats: { decoded: 0, rendered: 0, dropped: 0 },
+  fpsWindow: /** @type {number[]} */ ([]),
+  lastStatsPost: 0,
+
+  DECODE_QUEUE_MAX: 8,
+  MAX_RECOVERY: 8,
+  MAX_PENDING: 120,
+  MAX_RENDER_QUEUE: 6,
+};
+
+// Diagnostic note relayed to the bridge log via the main thread.
+function note(msg) {
+  post({ type: 'log', msg: '[video-worker] ' + msg });
+}
+
+function post(msg, transfer) {
+  self.postMessage(msg, transfer || []);
+}
+
+let lastIdrPost = 0;
+function askForIdr(reason) {
+  const now = performance.now();
+  if (now - lastIdrPost < 1000) return;
+  lastIdrPost = now;
+  post({ type: 'requestIdr', reason });
+}
+
+/* ─────────────────────────── decoder lifecycle ──────────────────────────── */
+
+function newDecoder() {
+  if (W.decoder) {
+    try {
+      W.decoder.close();
+    } catch (e) { /* already closed */ }
+  }
+  W.configured = false;
+  W.configuring = false;
+  W.decoder = new VideoDecoder({
+    output: onDecodedFrame,
+    error: (err) => {
+      note('decoder error: ' + (err && (err.name + ' ' + err.message)));
+      recoverDecoder();
+    },
+  });
+}
+
+function recoverDecoder() {
+  if (W.stopped) return;
+  if (++W.recoveryAttempts > W.MAX_RECOVERY) {
+    post({ type: 'fatal', msg: 'video decoder failed repeatedly' });
+    return;
+  }
+  note('recovering decoder (attempt ' + W.recoveryAttempts + ')');
+  for (const item of W.renderQueue) closeQuietly(item.frame);
+  W.renderQueue.length = 0;
+  W.pendingAus.length = 0;
+  W.referenceValid = false;
+  W.pacer.reset();
+  // Keep W.params: a recovery keyframe is not guaranteed to repeat the
+  // parameter sets, and the cached ones are still valid for this stream.
+  newDecoder();
+  if (W.params && W.params.ready()) configureDecoder();
+  askForIdr('decoder-error');
+}
+
+function closeQuietly(frame) {
+  try {
+    frame.close();
+  } catch (e) { /* already closed */ }
+}
+
+/**
+ * Build the ordered list of decoder configs to try.
+ *
+ * HEVC: Annex-B first — hev1.* strings with NO description (Chromium's HEVC
+ * keyframe validation only parses start codes), from the SPS-derived string
+ * down through common fallbacks, each with and without an explicit color
+ * space; then AVCC hvc1.* configs with an hvcC description.
+ *
+ * H.264: avc1 + avcC description first (SPS-derived string, then common
+ * fallbacks), progressively dropping colorSpace → dimensions → description.
+ *
+ * Each entry carries `annexB` so decode packaging matches the config.
+ * @returns {{config: VideoDecoderConfig, annexB: boolean}[]}
+ */
+function buildConfigCandidates() {
+  const dims = { codedWidth: 1920, codedHeight: 1080 };
+  const lat = { optimizeForLatency: true };
+  const cands = [];
+
+  if (W.codec === 'hevc') {
+    const primary = hevcCodecString(W.params.sps);
+    const hev1 = primary.replace(/^hvc1/, 'hev1');
+    const annexbStrings = [hev1];
+    for (const fb of HEVC_AVCC_FALLBACKS) {
+      const s = fb.replace(/^hvc1/, 'hev1');
+      if (!annexbStrings.includes(s)) annexbStrings.push(s);
+    }
+    for (const codec of annexbStrings) {
+      cands.push({ config: { codec, ...dims, ...lat, ...SDR_COLOR }, annexB: true });
+      cands.push({ config: { codec, ...dims, ...lat }, annexB: true });
+    }
+    const desc = buildHvcC(W.params.vps, W.params.sps, W.params.pps);
+    if (desc) {
+      const strings = [primary];
+      for (const fb of HEVC_AVCC_FALLBACKS) if (!strings.includes(fb)) strings.push(fb);
+      for (const codec of strings) {
+        cands.push({
+          config: { codec, description: desc.buffer, ...dims, ...lat, ...SDR_COLOR },
+          annexB: false,
+        });
+        cands.push({ config: { codec, description: desc.buffer, ...dims, ...lat }, annexB: false });
+      }
+      cands.push({ config: { codec: primary, description: desc.buffer }, annexB: false });
+    }
+    // Last-ditch: bare Annex-B without dimensions.
+    cands.push({ config: { codec: hev1, ...lat }, annexB: true });
+    return cands;
+  }
+
+  // H.264
+  const primary = h264CodecString(W.params.sps);
+  const desc = buildAvcC(W.params.sps, W.params.pps);
+  const strings = [primary];
+  for (const fb of H264_CODEC_FALLBACKS) if (!strings.includes(fb)) strings.push(fb);
+  for (const codec of strings) {
+    cands.push({
+      config: { codec, description: desc.buffer, ...dims, ...lat, ...SDR_COLOR },
+      annexB: false,
+    });
+    cands.push({ config: { codec, description: desc.buffer, ...dims, ...lat }, annexB: false });
+  }
+  // Progressive degradation on the primary string:
+  cands.push({ config: { codec: primary, description: desc.buffer, ...lat }, annexB: false });
+  cands.push({ config: { codec: primary, description: desc.buffer } , annexB: false });
+  // No description at all → Annex-B input.
+  cands.push({ config: { codec: primary, ...dims, ...lat }, annexB: true });
+  cands.push({ config: { codec: primary }, annexB: true });
+  return cands;
+}
+
+async function configureDecoder() {
+  if (W.stopped || W.configured || W.configuring || !W.params.ready()) return;
+  W.configuring = true;
+  const candidates = buildConfigCandidates();
+  const tried = [];
+  for (const cand of candidates) {
+    if (W.stopped) break;
+    const tag = cand.config.codec + (cand.config.description ? '+desc' : '') + (cand.annexB ? '/annexb' : '/avcc');
+    let supported = false;
+    try {
+      const res = await VideoDecoder.isConfigSupported(cand.config);
+      supported = !!(res && res.supported);
+    } catch (e) {
+      tried.push(tag + '!throw:' + (e && e.name));
+      continue;
+    }
+    if (!supported) {
+      tried.push(tag + '!unsup');
+      continue;
+    }
+    try {
+      W.decoder.configure(cand.config);
+      W.configured = true;
+      W.annexBMode = cand.annexB;
+      W.configuring = false;
+      note('configured ' + tag);
+      flushPendingAus();
+      return;
+    } catch (e) {
+      tried.push(tag + '!cfg:' + (e && e.name));
+      // configure() itself refused — move on down the waterfall.
+    }
+  }
+  W.configuring = false;
+  note('all configs failed: ' + tried.join(' '));
+  post({ type: 'fatal', msg: 'no supported ' + W.codec + ' decoder configuration' });
+}
+
+function flushPendingAus() {
+  // A decoder must see a keyframe first; drop leading deltas.
+  while (W.pendingAus.length && !W.pendingAus[0].keyframe) {
+    W.pendingAus.shift();
+    W.stats.dropped++;
+  }
+  const backlog = W.pendingAus;
+  W.pendingAus = [];
+  for (const au of backlog) decodeAu(au.data, au.keyframe, au.backendTs);
+}
+
+/* ─────────────────────────────── decoding ───────────────────────────────── */
+
+/**
+ * @param {Uint8Array} data — complete Annex-B AU
+ * @param {boolean} keyframe @param {number} backendTs
+ */
+function handleAu(data, keyframe, backendTs) {
+  if (W.stopped) return;
+
+  if (!W.sawFirstAu) {
+    W.sawFirstAu = true;
+    note('first AU: ' + data.length + 'B keyframe=' + keyframe);
+  }
+
+  // Track parameter sets. New/changed ones on a keyframe → (re)configure.
+  const nals = splitNals(data);
+  const changed = W.params.absorb(nals);
+  if (!W.notedParams && W.params.ready()) {
+    W.notedParams = true;
+    note('parameter sets acquired');
+  }
+  if (!W.configured) {
+    if (W.params.ready()) configureDecoder();
+    else if (!keyframe) {
+      // Waiting on parameter sets; nudge for a keyframe once in a while.
+      if (W.pendingAus.length % 30 === 29) askForIdr('waiting-for-params');
+    }
+  } else if (changed && keyframe) {
+    // Stream reconfigured (new SPS/PPS): rebuild the decoder around it.
+    console.log('[video-worker] parameter sets changed — reconfiguring');
+    for (const item of W.renderQueue) closeQuietly(item.frame);
+    W.renderQueue.length = 0;
+    W.pacer.reset();
+    newDecoder();
+    configureDecoder();
+  }
+
+  decodeAu(data, keyframe, backendTs);
+}
+
+function decodeAu(data, keyframe, backendTs) {
+  if (!W.configured) {
+    if (W.pendingAus.length < W.MAX_PENDING) W.pendingAus.push({ data, keyframe, backendTs });
+    return;
+  }
+  if (!W.decoder || W.decoder.state === 'closed') {
+    recoverDecoder();
+    return;
+  }
+  if (!keyframe && !W.referenceValid) {
+    W.stats.dropped++;
+    askForIdr('reference-invalid');
+    return;
+  }
+
+  // Backpressure: if the decode queue stays saturated, shed deltas and
+  // eventually assume the decoder wedged.
+  if (!keyframe && W.decoder.decodeQueueSize >= W.DECODE_QUEUE_MAX) {
+    const now = performance.now();
+    if (W.queueStallSince === 0) W.queueStallSince = now;
+    const stalled = now - W.queueStallSince;
+    if (stalled > 1000) {
+      W.queueStallSince = 0;
+      recoverDecoder();
+      return;
+    }
+    if (stalled > 200) {
+      W.stats.dropped++;
+      W.referenceValid = false;
+      askForIdr('decode-queue-overflow');
+      return;
+    }
+  } else {
+    W.queueStallSince = 0;
+  }
+
+  // Chunk timestamps: derive from backendTs (µs), kept strictly monotonic.
+  let ts = backendTs > 0 ? backendTs * 1000 : W.frameSeq * 16667;
+  if (ts <= W.lastChunkTs) ts = W.lastChunkTs + 1;
+  W.lastChunkTs = ts;
+  W.frameSeq++;
+
+  const payload = packageAu(data, W.codec, W.annexBMode);
+  if (payload.length === 0) return;
+  try {
+    const chunk = new EncodedVideoChunk({
+      type: keyframe ? 'key' : 'delta',
+      timestamp: ts,
+      duration: 16667,
+      data: payload,
+    });
+    submitTimes.set(ts, { perf: performance.now(), backendTs });
+    if (submitTimes.size > 240) submitTimes.clear();
+    W.decoder.decode(chunk);
+    if (keyframe) W.referenceValid = true;
+  } catch (e) {
+    W.stats.dropped++;
+    recoverDecoder();
+  }
+}
+
+/** chunk timestamp (µs) → submit bookkeeping, matched up in output(). */
+const submitTimes = new Map();
+
+/* ─────────────────────────── render scheduling ──────────────────────────── */
+
+/** @param {VideoFrame} frame */
+function onDecodedFrame(frame) {
+  W.stats.decoded++;
+  W.recoveryAttempts = 0;
+
+  const now = performance.now();
+  const submit = submitTimes.get(frame.timestamp);
+  let backendTs = 0;
+  if (submit) {
+    submitTimes.delete(frame.timestamp);
+    backendTs = submit.backendTs;
+  }
+
+  if (!W.firstFrameSent) {
+    W.firstFrameSent = true;
+    post({ type: 'firstFrame' });
+  }
+
+  const presentAt = W.pacer.schedule(backendTs, now);
+  if (W.renderQueue.length >= W.MAX_RENDER_QUEUE) {
+    // Memory bound; drop the oldest queued frame, keep the fresh one.
+    closeQuietly(W.renderQueue.shift().frame);
+    W.stats.dropped++;
+  }
+  W.renderQueue.push({ frame, presentAt });
+  armRenderLoop();
+}
+
+function armRenderLoop() {
+  if (W.renderLoopArmed || W.stopped) return;
+  W.renderLoopArmed = true;
+  // rAF exists in workers that own an OffscreenCanvas on modern engines;
+  // fall back to a short timer elsewhere.
+  if (typeof self.requestAnimationFrame === 'function') {
+    self.requestAnimationFrame(renderTick);
+  } else {
+    setTimeout(renderTick, 8);
+  }
+}
+
+function renderTick() {
+  W.renderLoopArmed = false;
+  if (W.stopped) return;
+  const now = performance.now();
+
+  // Collect all frames that are due; paint only the freshest of them.
+  let due = null;
+  while (W.renderQueue.length && W.renderQueue[0].presentAt <= now) {
+    if (due) {
+      closeQuietly(due.frame);
+      W.stats.dropped++;
+    }
+    due = W.renderQueue.shift();
+  }
+  if (due) paint(due.frame);
+  if (W.renderQueue.length) armRenderLoop();
+  postStats(false);
+}
+
+/** @param {VideoFrame} frame */
+function paint(frame) {
+  const w = frame.displayWidth || frame.codedWidth;
+  const h = frame.displayHeight || frame.codedHeight;
+  try {
+    if (W.canvas.width !== w || W.canvas.height !== h) {
+      W.canvas.width = w;
+      W.canvas.height = h;
+    }
+    W.ctx.drawImage(frame, 0, 0, w, h);
+    W.stats.rendered++;
+    W.fpsWindow.push(performance.now());
+    closeQuietly(frame);
+  } catch (e) {
+    // Some engines (WebKit) can refuse drawImage(VideoFrame) on a worker
+    // canvas; go through an ImageBitmap instead.
+    if (!W.notedPaintError) {
+      W.notedPaintError = true;
+      note('drawImage(VideoFrame) failed (' + (e && e.name) + '), using ImageBitmap path');
+    }
+    createImageBitmap(frame)
+      .then((bmp) => {
+        try {
+          W.ctx.drawImage(bmp, 0, 0, w, h);
+          W.stats.rendered++;
+          W.fpsWindow.push(performance.now());
+        } catch (e2) {
+          if (!W.notedBitmapError) {
+            W.notedBitmapError = true;
+            note('ImageBitmap paint failed too: ' + (e2 && e2.name));
+          }
+        }
+        bmp.close();
+      })
+      .catch((e2) => {
+        if (!W.notedBitmapError) {
+          W.notedBitmapError = true;
+          note('createImageBitmap(VideoFrame) failed: ' + (e2 && e2.name));
+        }
+      })
+      .finally(() => closeQuietly(frame));
+  }
+}
+
+function postStats(force) {
+  const now = performance.now();
+  if (!force && now - W.lastStatsPost < 500) return;
+  W.lastStatsPost = now;
+  const cutoff = now - 2000;
+  while (W.fpsWindow.length && W.fpsWindow[0] < cutoff) W.fpsWindow.shift();
+  post({
+    type: 'stats',
+    fps: W.fpsWindow.length / 2,
+    decoded: W.stats.decoded,
+    rendered: W.stats.rendered,
+    dropped: W.stats.dropped,
+    decodeQueue: W.decoder ? W.decoder.decodeQueueSize : 0,
+    renderQueue: W.renderQueue.length,
+    holdbackMs: Math.round(W.pacer.target * 10) / 10,
+  });
+}
+
+/* ─────────────────────────── message dispatch ───────────────────────────── */
+
+self.onmessage = (e) => {
+  const m = e.data;
+  switch (m.type) {
+    case 'init': {
+      W.canvas = m.canvas;
+      W.codec = m.codec === 'hevc' ? 'hevc' : 'h264';
+      W.params = new ParamSets(W.codec);
+      if (typeof VideoDecoder === 'undefined') {
+        post({ type: 'fatal', msg: 'WebCodecs is not available in this browser' });
+        return;
+      }
+      W.ctx = W.canvas.getContext('2d', { alpha: false, desynchronized: true });
+      if (!W.ctx) W.ctx = W.canvas.getContext('2d'); // engines picky about options
+      if (!W.ctx) {
+        post({ type: 'fatal', msg: 'could not create canvas context' });
+        return;
+      }
+      newDecoder();
+      break;
+    }
+    case 'frame':
+      handleAu(new Uint8Array(m.data), !!m.keyframe, m.backendTs || 0);
+      break;
+    case 'frameLoss':
+      // Upstream saw a frameId gap: deltas past it reference missing frames.
+      W.referenceValid = false;
+      break;
+    case 'stop':
+      W.stopped = true;
+      if (W.decoder) {
+        try {
+          W.decoder.close();
+        } catch (e2) { /* already closed */ }
+        W.decoder = null;
+      }
+      for (const item of W.renderQueue) closeQuietly(item.frame);
+      W.renderQueue.length = 0;
+      W.pendingAus.length = 0;
+      break;
+    default:
+      break;
+  }
+};

--- a/webbridge/frontend/js/video.js
+++ b/webbridge/frontend/js/video.js
@@ -1,0 +1,241 @@
+/**
+ * video.js — main-thread side of the video pipeline.
+ *
+ * Reassembles the 17-byte-header fragments from the "video" DataChannel into
+ * complete Annex-B access units (PROTOCOL.md "Video fragment format"), detects
+ * frameId gaps / stale incomplete frames, and hands finished AUs to the decode
+ * worker (VideoDecoder + OffscreenCanvas) with a transferred buffer.
+ */
+
+const HEADER_SIZE = 17;
+const FLAG_KEYFRAME = 0x01;
+// An incomplete frame older than this (vs the newest frameId seen) is dead:
+// the channel gave up retransmitting one of its chunks.
+const STALE_FRAME_WINDOW = 4;
+const MAX_PENDING_FRAMES = 16;
+
+/** Serial-number distance a-b for u32 frameIds (handles wrap). */
+function idDelta(a, b) {
+  return (a - b) | 0; // wraps into signed 32-bit distance
+}
+
+/**
+ * @typedef {object} PendingFrame
+ * @property {Uint8Array[]} chunks
+ * @property {number} received
+ * @property {number} total
+ * @property {number} bytes
+ * @property {boolean} keyframe
+ * @property {number} backendTs
+ */
+
+export class FrameAssembler {
+  /**
+   * @param {(au: Uint8Array, keyframe: boolean, backendTs: number) => void} onFrame
+   * @param {() => void} onLoss — a frameId gap was observed
+   */
+  constructor(onFrame, onLoss) {
+    this.onFrame = onFrame;
+    this.onLoss = onLoss;
+    /** @type {Map<number, PendingFrame>} */
+    this.pending = new Map();
+    this.lastDelivered = -1;
+    this.newestSeen = -1;
+    this.haveDelivered = false;
+  }
+
+  reset() {
+    this.pending.clear();
+    this.lastDelivered = -1;
+    this.newestSeen = -1;
+    this.haveDelivered = false;
+  }
+
+  /** @param {ArrayBuffer} buf — one DataChannel message (one fragment) */
+  push(buf) {
+    if (buf.byteLength < HEADER_SIZE) return;
+    const dv = new DataView(buf);
+    const frameId = dv.getUint32(0); // big-endian
+    const chunkIndex = dv.getUint16(4);
+    const totalChunks = dv.getUint16(6);
+    const flags = dv.getUint8(8);
+    const payloadSize = dv.getUint32(9);
+    const backendTs = dv.getUint32(13);
+
+    if (totalChunks === 0 || chunkIndex >= totalChunks) return;
+    if (HEADER_SIZE + payloadSize > buf.byteLength) return; // truncated
+    const payload = new Uint8Array(buf, HEADER_SIZE, payloadSize);
+
+    // Frame already behind us? (retransmit that lost the race)
+    if (this.haveDelivered && idDelta(frameId, this.lastDelivered) <= 0) return;
+
+    if (this.newestSeen === -1 || idDelta(frameId, this.newestSeen) > 0) {
+      this.newestSeen = frameId;
+    }
+
+    let entry = this.pending.get(frameId);
+    if (!entry) {
+      entry = {
+        chunks: new Array(totalChunks),
+        received: 0,
+        total: totalChunks,
+        bytes: 0,
+        keyframe: (flags & FLAG_KEYFRAME) !== 0,
+        backendTs,
+      };
+      this.pending.set(frameId, entry);
+    }
+    if (entry.chunks[chunkIndex] === undefined) {
+      // Copy out of the message buffer: the payload view aliases the DC
+      // message and we may hold it across messages.
+      entry.chunks[chunkIndex] = payload.slice();
+      entry.received++;
+      entry.bytes += payloadSize;
+      entry.keyframe = entry.keyframe || (flags & FLAG_KEYFRAME) !== 0;
+    }
+
+    if (entry.received === entry.total) {
+      this.pending.delete(frameId);
+      this._deliver(frameId, entry);
+    }
+
+    this._dropStale();
+  }
+
+  /** @param {number} frameId @param {PendingFrame} entry */
+  _deliver(frameId, entry) {
+    const au = new Uint8Array(entry.bytes);
+    let off = 0;
+    for (const c of entry.chunks) {
+      au.set(c, off);
+      off += c.length;
+    }
+    if (this.haveDelivered) {
+      const gap = idDelta(frameId, this.lastDelivered);
+      if (gap > 1) this.onLoss();
+    }
+    this.lastDelivered = frameId;
+    this.haveDelivered = true;
+    this.onFrame(au, entry.keyframe, entry.backendTs);
+  }
+
+  _dropStale() {
+    let lost = false;
+    for (const [id] of this.pending) {
+      if (idDelta(this.newestSeen, id) > STALE_FRAME_WINDOW) {
+        this.pending.delete(id);
+        lost = true;
+      }
+    }
+    if (this.pending.size > MAX_PENDING_FRAMES) {
+      // Pathological: shed oldest first.
+      const ids = [...this.pending.keys()].sort((a, b) => idDelta(a, b));
+      while (ids.length > MAX_PENDING_FRAMES) {
+        this.pending.delete(ids.shift());
+        lost = true;
+      }
+    }
+    if (lost) this.onLoss();
+  }
+}
+
+export class VideoPipeline {
+  /**
+   * @param {HTMLCanvasElement} canvas — will be transferred to the worker
+   * @param {'h264'|'hevc'} codec — expected codec from streamInfo
+   * @param {{
+   *   requestIdr: () => void,
+   *   onStats?: (stats: object) => void,
+   *   onFirstFrame?: () => void,
+   *   onFatal?: (msg: string) => void,
+   * }} cbs
+   */
+  constructor(canvas, codec, cbs) {
+    this.cbs = cbs;
+    this.stopped = false;
+    this._lastIdrReq = 0;
+
+    this.worker = new Worker(new URL('./video-worker.js', import.meta.url), {
+      type: 'module',
+    });
+    const offscreen = canvas.transferControlToOffscreen();
+    this.worker.postMessage({ type: 'init', canvas: offscreen, codec }, [offscreen]);
+
+    // An uncaught exception in the worker would otherwise be a silent black
+    // screen — surface it.
+    this.worker.onerror = (e) => {
+      const msg = 'worker uncaught: ' + (e.message || 'unknown') + ' @' + (e.filename || '') + ':' + (e.lineno || 0);
+      if (cbs.onLog) cbs.onLog('[video] ' + msg);
+      if (cbs.onFatal) cbs.onFatal(msg);
+    };
+
+    this.worker.onmessage = (e) => {
+      const m = e.data;
+      switch (m.type) {
+        case 'requestIdr':
+          this._requestIdr();
+          break;
+        case 'stats':
+          if (cbs.onStats) cbs.onStats(m);
+          break;
+        case 'firstFrame':
+          if (cbs.onFirstFrame) cbs.onFirstFrame();
+          break;
+        case 'fatal':
+          if (cbs.onFatal) cbs.onFatal(m.msg || 'video decoder failed');
+          break;
+        case 'log':
+          if (cbs.onLog) cbs.onLog(m.msg);
+          break;
+        default:
+          break;
+      }
+    };
+
+    this.assembler = new FrameAssembler(
+      (au, keyframe, backendTs) => {
+        if (this.stopped) return;
+        this.worker.postMessage(
+          { type: 'frame', data: au.buffer, keyframe, backendTs },
+          [au.buffer],
+        );
+      },
+      () => {
+        if (this.stopped) return;
+        this.worker.postMessage({ type: 'frameLoss' });
+        this._requestIdr();
+      },
+    );
+  }
+
+  /** Rate-limited IDR request toward the bridge (1/s). */
+  _requestIdr() {
+    const now = performance.now();
+    if (now - this._lastIdrReq < 1000) return;
+    this._lastIdrReq = now;
+    this.cbs.requestIdr();
+  }
+
+  /** @param {ArrayBuffer} buf — raw video-DC message */
+  pushFragment(buf) {
+    if (!this.stopped) this.assembler.push(buf);
+  }
+
+  /**
+   * The transport was swapped mid-session: frameIds restart from 0, so the
+   * assembler's "behind lastDelivered" duplicate filter must be cleared.
+   */
+  resetStream() {
+    this.assembler.reset();
+  }
+
+  destroy() {
+    this.stopped = true;
+    try {
+      this.worker.postMessage({ type: 'stop' });
+    } catch (e) { /* worker gone */ }
+    // Give the worker a beat to close the decoder before hard-terminating.
+    const w = this.worker;
+    setTimeout(() => w.terminate(), 250);
+  }
+}

--- a/webbridge/frontend/js/virtual-gamepad.js
+++ b/webbridge/frontend/js/virtual-gamepad.js
@@ -1,0 +1,300 @@
+/**
+ * virtual-gamepad.js — touch overlay for the stream view.
+ *
+ * Left virtual thumbstick (movement), right virtual thumbstick (camera look),
+ * d-pad, right face-button cluster, shoulder zones and small system buttons.
+ * Multi-touch correct via Pointer Events (each finger has its own pointerId;
+ * every control captures its pointer). Writes its state into
+ * InputManager.overlayState — the merger in input.js does the rest.
+ */
+
+import { BTN } from './input.js';
+
+const STICK_MAX = 32767;
+
+/** @param {string} tag @param {string} cls @param {string} [text] */
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  n.className = cls;
+  if (text !== undefined) n.textContent = text;
+  return n;
+}
+
+export class VirtualGamepad {
+  /**
+   * @param {HTMLElement} parent — stream view container
+   * @param {import('./input.js').InputManager} input
+   */
+  constructor(parent, input) {
+    this.input = input;
+    this.pressed = new Set(); // chiaki flags held by touches
+    this.l2 = 0;
+    this.r2 = 0;
+    this.stick = { x: 0, y: 0 };   // left stick — movement (lx/ly)
+    this.rstick = { x: 0, y: 0 };  // right stick — camera look (rx/ry)
+    this._stickPointer = -1;
+    this._rstickPointer = -1;
+
+    this.root = el('div', 'vpad');
+    this.root.setAttribute('aria-hidden', 'true');
+    parent.appendChild(this.root);
+
+    this._buildStick();
+    this._buildRightStick();
+    this._buildDpad();
+    this._buildFaceCluster();
+    this._buildShoulders();
+    this._buildSystemRow();
+
+    this.hide();
+  }
+
+  show() {
+    this.root.classList.add('vpad-visible');
+  }
+
+  hide() {
+    this.root.classList.remove('vpad-visible');
+    this._resetAll();
+  }
+
+  get visible() {
+    return this.root.classList.contains('vpad-visible');
+  }
+
+  destroy() {
+    this.root.remove();
+  }
+
+  _resetAll() {
+    this.pressed.clear();
+    this.l2 = 0;
+    this.r2 = 0;
+    this.stick.x = 0;
+    this.stick.y = 0;
+    this.rstick.x = 0;
+    this.rstick.y = 0;
+    this._stickPointer = -1;
+    this._rstickPointer = -1;
+    if (this.nub) this.nub.style.transform = 'translate(0px, 0px)';
+    if (this.rnub) this.rnub.style.transform = 'translate(0px, 0px)';
+    this._publish();
+  }
+
+  _publish() {
+    let b = 0;
+    for (const f of this.pressed) b |= f;
+    this.input.overlayState = {
+      b,
+      l2: this.l2,
+      r2: this.r2,
+      lx: Math.round(this.stick.x * STICK_MAX),
+      ly: Math.round(this.stick.y * STICK_MAX), // positive = down
+      rx: Math.round(this.rstick.x * STICK_MAX),
+      ry: Math.round(this.rstick.y * STICK_MAX), // positive = down
+    };
+  }
+
+  /**
+   * Wire a hold-to-press control.
+   * @param {HTMLElement} node
+   * @param {() => void} down @param {() => void} up
+   */
+  _pressable(node, down, up) {
+    node.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      try { node.setPointerCapture(e.pointerId); } catch { /* synthetic or stale pointer */ }
+      node.classList.add('vpad-active');
+      this.input.onUserGesture();
+      down();
+      this._publish();
+    });
+    const end = (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      node.classList.remove('vpad-active');
+      up();
+      this._publish();
+    };
+    node.addEventListener('pointerup', end);
+    node.addEventListener('pointercancel', end);
+  }
+
+  /** @param {HTMLElement} node @param {number} flag */
+  _button(node, flag) {
+    this._pressable(
+      node,
+      () => this.pressed.add(flag),
+      () => this.pressed.delete(flag),
+    );
+  }
+
+  /* ── thumbsticks ── */
+
+  _buildStick() {
+    this.nub = this._makeStick('vpad-lstick-zone', this.stick, 'left');
+  }
+
+  _buildRightStick() {
+    this.rnub = this._makeStick('vpad-rstick-zone', this.rstick, 'right');
+  }
+
+  /**
+   * Build a floating analog thumbstick.
+   * @param {string} zoneCls — CSS class positioning the touch zone
+   * @param {{x:number,y:number}} state — normalized axis output written here
+   * @param {'left'|'right'} which — selects the pointer-tracking field
+   * @returns {HTMLElement} the nub element (for reset transforms)
+   */
+  _makeStick(zoneCls, state, which) {
+    const ptrField = which === 'left' ? '_stickPointer' : '_rstickPointer';
+    const zone = el('div', `vpad-stick-zone ${zoneCls}`);
+    const base = el('div', 'vpad-stick-base');
+    const nub = el('div', 'vpad-stick-nub');
+    base.appendChild(nub);
+    zone.appendChild(base);
+    this.root.appendChild(zone);
+
+    const RADIUS = 60; // px of nub travel
+    const EXPO = 1.25; // >1 gently softens small movements, keeps full range at edge
+
+    const track = (e) => {
+      const rect = base.getBoundingClientRect();
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      let dx = e.clientX - cx;
+      let dy = e.clientY - cy;
+      const mag = Math.hypot(dx, dy);
+      if (mag > RADIUS) {
+        dx = (dx / mag) * RADIUS;
+        dy = (dy / mag) * RADIUS;
+      }
+      nub.style.transform = `translate(${dx}px, ${dy}px)`;
+      // Response shaping: a mild expo curve so the stick is a touch less twitchy.
+      // The nub tracks the finger linearly; only the emitted axes are shaped.
+      const m = Math.min(1, mag / RADIUS); // clamped deflection 0..1
+      const out = Math.pow(m, EXPO);
+      const len = Math.hypot(dx, dy) || 1; // unit direction from clamped offset
+      state.x = (dx / len) * out;
+      state.y = (dy / len) * out;
+      this._publish();
+    };
+
+    zone.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (this[ptrField] !== -1) return;
+      this[ptrField] = e.pointerId;
+      try { zone.setPointerCapture(e.pointerId); } catch { /* synthetic or stale pointer */ }
+      this.input.onUserGesture();
+      track(e);
+    });
+    zone.addEventListener('pointermove', (e) => {
+      if (e.pointerId !== this[ptrField]) return;
+      e.preventDefault();
+      track(e);
+    });
+    const release = (e) => {
+      if (e.pointerId !== this[ptrField]) return;
+      e.preventDefault();
+      this[ptrField] = -1;
+      state.x = 0;
+      state.y = 0;
+      nub.style.transform = 'translate(0px, 0px)';
+      this._publish();
+    };
+    zone.addEventListener('pointerup', release);
+    zone.addEventListener('pointercancel', release);
+
+    return nub;
+  }
+
+  /* ── d-pad ── */
+
+  _buildDpad() {
+    const pad = el('div', 'vpad-dpad');
+    const dirs = [
+      ['up', BTN.DPAD_UP, '▲'],
+      ['left', BTN.DPAD_LEFT, '◀'],
+      ['right', BTN.DPAD_RIGHT, '▶'],
+      ['down', BTN.DPAD_DOWN, '▼'],
+    ];
+    for (const [name, flag, glyph] of dirs) {
+      const b = el('button', `vpad-btn vpad-dpad-${name}`, glyph);
+      b.type = 'button';
+      this._button(b, flag);
+      pad.appendChild(b);
+    }
+    this.root.appendChild(pad);
+  }
+
+  /* ── face buttons ── */
+
+  _buildFaceCluster() {
+    const cluster = el('div', 'vpad-face');
+    const defs = [
+      ['pyramid', BTN.PYRAMID, '△'],
+      ['box', BTN.BOX, '□'],
+      ['moon', BTN.MOON, '○'],
+      ['cross', BTN.CROSS, '✕'],
+    ];
+    for (const [name, flag, glyph] of defs) {
+      const b = el('button', `vpad-btn vpad-face-${name}`, glyph);
+      b.type = 'button';
+      this._button(b, flag);
+      cluster.appendChild(b);
+    }
+    this.root.appendChild(cluster);
+  }
+
+  /* ── shoulders / triggers ── */
+
+  _buildShoulders() {
+    const defs = [
+      ['l2', 'L2', 'left', (v) => (this.l2 = v ? 255 : 0)],
+      ['l1', 'L1', 'left', null, BTN.L1],
+      ['r1', 'R1', 'right', null, BTN.R1],
+      ['r2', 'R2', 'right', (v) => (this.r2 = v ? 255 : 0)],
+    ];
+    const left = el('div', 'vpad-shoulders vpad-shoulders-left');
+    const right = el('div', 'vpad-shoulders vpad-shoulders-right');
+    for (const [name, label, side, setTrigger, flag] of defs) {
+      const b = el('button', `vpad-btn vpad-shoulder vpad-${name}`, label);
+      b.type = 'button';
+      if (setTrigger) {
+        this._pressable(b, () => setTrigger(true), () => setTrigger(false));
+      } else {
+        this._button(b, flag);
+      }
+      (side === 'left' ? left : right).appendChild(b);
+    }
+    this.root.appendChild(left);
+    this.root.appendChild(right);
+  }
+
+  /* ── share / touchpad / ps / options ── */
+
+  _buildSystemRow() {
+    const row = el('div', 'vpad-system');
+    const defs = [
+      ['SHARE', BTN.SHARE],
+      ['PAD', BTN.TOUCHPAD],
+      ['PS', BTN.PS],
+      ['OPT', BTN.OPTIONS],
+    ];
+    for (const [label, flag] of defs) {
+      const b = el('button', 'vpad-btn vpad-sys', label);
+      b.type = 'button';
+      this._button(b, flag);
+      row.appendChild(b);
+    }
+    this.root.appendChild(row);
+  }
+}
+
+/** True when this device should get the touch overlay by default. */
+export function isTouchDevice() {
+  const coarse = window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
+  return coarse || (navigator.maxTouchPoints || 0) > 0;
+}

--- a/webbridge/frontend/js/webrtc.js
+++ b/webbridge/frontend/js/webrtc.js
@@ -1,0 +1,265 @@
+/**
+ * webrtc.js — RTCPeerConnection wrapper for the chiaki-web bridge.
+ *
+ * The bridge is ALWAYS the offerer (PROTOCOL.md): audio arrives as a remote
+ * Opus track, video and input ride on pre-negotiated DataChannels that both
+ * sides create with identical ids/reliability:
+ *
+ *   "video": negotiated, id 0, ordered, maxRetransmits 3  (binary fragments)
+ *   "input": negotiated, id 2, reliable ordered           (JSON text)
+ */
+
+export class RtcSession {
+  /**
+   * @param {import('./signaling.js').Signaling} signaling
+   * @param {RTCIceServer[]} [iceServers] — STUN/TURN minted by the bridge
+   *   (Cloudflare TURN). Empty on LAN: host candidates suffice there.
+   */
+  constructor(signaling, iceServers = []) {
+    this.signaling = signaling;
+    this.isWs = false;
+    this.pc = new RTCPeerConnection({ iceServers });
+    if (iceServers.length) {
+      signaling.log('[rtc] using ' + iceServers.length + ' ICE server entr' +
+        (iceServers.length === 1 ? 'y' : 'ies') + ' (TURN fallback available)');
+    }
+
+    /** @type {(data: ArrayBuffer) => void} fired per video fragment */
+    this.onVideoData = () => {};
+    /** @type {(msg: object) => void} fired per input-DC JSON message */
+    this.onInputMessage = () => {};
+    /** @type {(state: string) => void} */
+    this.onConnectionState = () => {};
+    /** @type {() => void} first time both channels + ICE are up */
+    this.onReady = () => {};
+
+    this._readyFired = false;
+    this._pendingCandidates = [];
+    this._haveRemote = false;
+
+    // Negotiated channels must exist before the SDP answer is generated so
+    // the SCTP association carries them; ids/settings must mirror the bridge.
+    this.videoDC = this.pc.createDataChannel('video', {
+      negotiated: true,
+      id: 0,
+      ordered: true,
+      maxRetransmits: 3,
+    });
+    this.videoDC.binaryType = 'arraybuffer';
+    this.videoDC.onmessage = (ev) => {
+      if (ev.data instanceof ArrayBuffer) this.onVideoData(ev.data);
+    };
+    this.videoDC.onopen = () => {
+      this.signaling.log('[rtc] video DC open');
+      this._maybeReady();
+    };
+
+    this.inputDC = this.pc.createDataChannel('input', {
+      negotiated: true,
+      id: 2,
+    });
+    this.inputDC.binaryType = 'arraybuffer';
+    this.inputDC.onmessage = (ev) => {
+      if (typeof ev.data !== 'string') return;
+      try {
+        const msg = JSON.parse(ev.data);
+        if (msg && typeof msg === 'object') this.onInputMessage(msg);
+      } catch (e) {
+        /* malformed input message — ignore */
+      }
+    };
+    this.inputDC.onopen = () => this._maybeReady();
+
+    // Microphone PCM (browser -> bridge): unordered + lossy, mirrors the
+    // bridge's negotiated channel id 4. 48 kHz mono s16le chunks.
+    this.micDC = this.pc.createDataChannel('mic', {
+      negotiated: true,
+      id: 4,
+      ordered: false,
+      maxRetransmits: 0,
+    });
+    this.micDC.binaryType = 'arraybuffer';
+
+    // Remote audio: hand the track to a hidden <audio> element and let the
+    // browser's jitter buffer / FEC / PLC do the work.
+    this.audioEl = document.createElement('audio');
+    this.audioEl.autoplay = true;
+    this.audioEl.setAttribute('playsinline', '');
+    this.audioEl.style.display = 'none';
+    document.body.appendChild(this.audioEl);
+    this._audioBlocked = false;
+
+    this.pc.ontrack = (ev) => {
+      if (ev.track.kind !== 'audio') return;
+      this.signaling.log('[audio] track received (muted=' + ev.track.muted + ')');
+      ev.track.onunmute = () => this.signaling.log('[audio] track unmuted (RTP flowing)');
+      const stream = ev.streams && ev.streams[0] ? ev.streams[0] : new MediaStream([ev.track]);
+      this.audioEl.srcObject = stream;
+      this._tryPlayAudio();
+    };
+
+    this.pc.onicecandidate = (ev) => {
+      if (ev.candidate && ev.candidate.candidate) {
+        this.signaling.candidate(ev.candidate.candidate, ev.candidate.sdpMid || '0');
+      }
+    };
+
+    this.pc.onconnectionstatechange = () => {
+      this.onConnectionState(this.pc.connectionState);
+      if (this.pc.connectionState === 'connected') {
+        this._logSelectedPair();
+        this._maybeReady();
+      }
+    };
+  }
+
+  /** Telemetry: which candidate pair won (host = direct, relay = TURN). */
+  async _logSelectedPair() {
+    try {
+      const stats = await this.pc.getStats();
+      let pair = null;
+      stats.forEach((s) => {
+        if (s.type === 'transport' && s.selectedCandidatePairId) pair = stats.get(s.selectedCandidatePairId);
+      });
+      if (!pair) {
+        stats.forEach((s) => {
+          if (s.type === 'candidate-pair' && (s.selected || s.nominated) && s.state === 'succeeded') pair = s;
+        });
+      }
+      if (!pair) return;
+      const local = stats.get(pair.localCandidateId);
+      const remote = stats.get(pair.remoteCandidateId);
+      this.signaling.log('[rtc] selected pair: local=' + (local && local.candidateType) +
+        ' remote=' + (remote && remote.candidateType));
+    } catch { /* stats unavailable */ }
+  }
+
+  _maybeReady() {
+    if (this._readyFired) return;
+    if (
+      this.videoDC.readyState === 'open' &&
+      this.inputDC.readyState === 'open' &&
+      (this.pc.connectionState === 'connected' || this.pc.connectionState === 'connecting')
+    ) {
+      this._readyFired = true;
+      this.onReady();
+    }
+  }
+
+  _tryPlayAudio() {
+    const p = this.audioEl.play();
+    if (p && p.catch) {
+      p.then(() => {
+        this._audioBlocked = false;
+        this.signaling.log('[audio] playing');
+      }).catch((e) => {
+        // Autoplay policy (iOS Safari & friends): retry on first gesture.
+        this._audioBlocked = true;
+        this.signaling.log('[audio] autoplay blocked: ' + (e && e.name));
+      });
+    }
+  }
+
+  /**
+   * Call from any user-gesture handler; unblocks audio if autoplay was denied.
+   */
+  resumeAudio() {
+    if (this._audioBlocked || this.audioEl.paused) this._tryPlayAudio();
+  }
+
+  /**
+   * Handle the bridge's SDP offer: setRemote → createAnswer → setLocal →
+   * signal the answer. Flushes any candidates that raced the offer.
+   * @param {string} sdp
+   */
+  async acceptOffer(sdp) {
+    await this.pc.setRemoteDescription({ type: 'offer', sdp });
+    this._haveRemote = true;
+    const answer = await this.pc.createAnswer();
+    await this.pc.setLocalDescription(answer);
+    this.signaling.answer(this.pc.localDescription.sdp);
+    for (const c of this._pendingCandidates) this._addCandidate(c);
+    this._pendingCandidates = [];
+  }
+
+  /**
+   * Trickled remote candidate from the bridge.
+   * @param {string} candidate @param {string} mid
+   */
+  addRemoteCandidate(candidate, mid) {
+    const init = { candidate, sdpMid: mid };
+    if (!this._haveRemote) {
+      this._pendingCandidates.push(init);
+      return;
+    }
+    this._addCandidate(init);
+  }
+
+  _addCandidate(init) {
+    this.pc.addIceCandidate(init).catch((e) => {
+      console.warn('[webrtc] addIceCandidate failed:', e && e.message);
+    });
+  }
+
+  /**
+   * Send a JSON message on the input DC.
+   * @param {object} msg — e.g. {t:'cs',...} / {t:'idr'} / {t:'pin',...}
+   * @returns {boolean} true if the channel accepted it
+   */
+  sendInput(msg) {
+    if (this.inputDC.readyState !== 'open') return false;
+    try {
+      this.inputDC.send(JSON.stringify(msg));
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * Send a microphone PCM chunk (Int16Array buffer) on the mic DC.
+   * @param {ArrayBuffer} buf
+   * @returns {boolean}
+   */
+  sendMic(buf) {
+    if (!this.micDC || this.micDC.readyState !== 'open') return false;
+    try {
+      this.micDC.send(buf);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /** Bytes received on the video DC so far (for the HUD bitrate estimate). */
+  async getVideoBytesReceived() {
+    let bytes = 0;
+    try {
+      const stats = await this.pc.getStats();
+      stats.forEach((s) => {
+        if (s.type === 'data-channel' && s.label === 'video') {
+          bytes = s.bytesReceived || 0;
+        }
+      });
+    } catch (e) {
+      /* stats unavailable */
+    }
+    return bytes;
+  }
+
+  close() {
+    try {
+      this.videoDC.close();
+    } catch (e) { /* noop */ }
+    try {
+      this.inputDC.close();
+    } catch (e) { /* noop */ }
+    try {
+      this.pc.close();
+    } catch (e) { /* noop */ }
+    if (this.audioEl) {
+      this.audioEl.srcObject = null;
+      this.audioEl.remove();
+    }
+  }
+}

--- a/webbridge/frontend/js/ws-transport.js
+++ b/webbridge/frontend/js/ws-transport.js
@@ -1,0 +1,185 @@
+/**
+ * ws-transport.js — WebSocket media transport (fallback for networks where
+ * WebRTC cannot connect: UDP-hostile wifi, symmetric NATs beyond TURN).
+ *
+ * Everything rides the signaling WebSocket. Binary messages carry a 1-byte
+ * channel prefix (PROTOCOL.md "WebSocket transport"):
+ *   0x01 bridge→browser  video: 17-byte fragment header + Annex-B AU
+ *   0x02 bridge→browser  audio: interleaved s16le PCM (bridge decodes Opus)
+ *   0x03 browser→bridge  mic:   48 kHz mono s16le PCM
+ * Input/events are JSON text on the same socket ("t"-keyed).
+ *
+ * Exposes the same surface as RtcSession so app.js can treat both alike.
+ */
+
+const CHAN_VIDEO = 0x01;
+const CHAN_AUDIO = 0x02;
+const CHAN_MIC = 0x03;
+
+export class WsSession {
+  /** @param {import('./signaling.js').Signaling} signaling */
+  constructor(signaling) {
+    this.signaling = signaling;
+    this.isWs = true;
+
+    /** @type {(data: ArrayBuffer) => void} fired per video fragment */
+    this.onVideoData = () => {};
+    /** @type {(msg: object) => void} input/event message from the bridge */
+    this.onInputMessage = () => {};
+    /** @type {(state: string) => void} */
+    this.onConnectionState = () => {};
+    /** @type {() => void} */
+    this.onReady = () => {};
+
+    this._readyFired = false;
+    this._videoBytes = 0;
+    this._audio = new PcmPlayer((msg) => signaling.log(msg));
+
+    signaling.onbinary = (buf) => this._onBinary(buf);
+  }
+
+  _onBinary(buf) {
+    if (buf.byteLength < 1) return;
+    const chan = new Uint8Array(buf, 0, 1)[0];
+    if (chan === CHAN_VIDEO) {
+      this._videoBytes += buf.byteLength - 1;
+      this.onVideoData(buf.slice(1));
+    } else if (chan === CHAN_AUDIO) {
+      this._audio.push(buf);
+    }
+  }
+
+  /** Bridge signaling that concerns the transport. @param {object} msg */
+  handleSignal(msg) {
+    if (msg.type === 'audioInfo') {
+      this._audio.configure(msg.rate || 48000, msg.channels || 2);
+    } else if (msg.type === 'status' && msg.state === 'connected') {
+      if (!this._readyFired) {
+        this._readyFired = true;
+        this.onConnectionState('connected');
+        this.onReady();
+      }
+    }
+  }
+
+  /** @param {object} msg @returns {boolean} */
+  sendInput(msg) {
+    if (!this.signaling.ws || this.signaling.ws.readyState !== WebSocket.OPEN) return false;
+    this.signaling.send(msg); // "t"-keyed: the bridge routes it to input
+    return true;
+  }
+
+  /** @param {ArrayBuffer} buf mic PCM chunk @returns {boolean} */
+  sendMic(buf) {
+    const msg = new Uint8Array(1 + buf.byteLength);
+    msg[0] = CHAN_MIC;
+    msg.set(new Uint8Array(buf), 1);
+    return this.signaling.sendBinary(msg);
+  }
+
+  resumeAudio() {
+    this._audio.resume();
+  }
+
+  async getVideoBytesReceived() {
+    return this._videoBytes;
+  }
+
+  close() {
+    this.signaling.onbinary = () => {};
+    this._audio.close();
+  }
+}
+
+/**
+ * Raw-PCM playback via an AudioWorklet with its own jitter buffer (see
+ * pcm-player-worklet.js). Tolerates configure()/push() in any order and
+ * before the (async) worklet finishes loading.
+ */
+class PcmPlayer {
+  /** @param {(msg: string) => void} log */
+  constructor(log) {
+    this.log = log;
+    this.ctx = null;
+    this.node = null;
+    this.rate = 48000;
+    this.channels = 2;
+    this._starting = null;
+    /** @type {ArrayBuffer[]} audio received while the worklet loads */
+    this._preBuffer = [];
+    this.closed = false;
+  }
+
+  configure(rate, channels) {
+    this.rate = rate;
+    this.channels = channels;
+    if (this.node) {
+      this.node.port.postMessage({ config: { rate, channels } });
+    }
+  }
+
+  /** @param {ArrayBuffer} buf channel-prefixed audio message */
+  push(buf) {
+    if (this.closed) return;
+    if (!this.node) {
+      if (!this._starting) this._starting = this._start();
+      if (this._preBuffer.length < 32) this._preBuffer.push(buf);
+      return;
+    }
+    this._post(buf);
+  }
+
+  _post(buf) {
+    // Odd payload would misalign Int16Array; trim the prefix via slice.
+    const pcm = new Int16Array(buf.slice(1));
+    this.node.port.postMessage({ pcm }, [pcm.buffer]);
+  }
+
+  async _start() {
+    try {
+      const Ctx = window.AudioContext || window.webkitAudioContext;
+      this.ctx = new Ctx({ sampleRate: this.rate, latencyHint: 'interactive' });
+    } catch {
+      this.ctx = new (window.AudioContext || window.webkitAudioContext)();
+    }
+    try {
+      await this.ctx.audioWorklet.addModule('js/pcm-player-worklet.js');
+    } catch (e) {
+      this.log('[audio] pcm worklet load failed: ' + (e && e.message));
+      return;
+    }
+    if (this.closed) return;
+    this.node = new AudioWorkletNode(this.ctx, 'pcm-player', {
+      numberOfInputs: 0,
+      numberOfOutputs: 1,
+      outputChannelCount: [Math.max(2, this.channels)],
+    });
+    this.node.connect(this.ctx.destination);
+    this.node.port.postMessage({ config: { rate: this.rate, channels: this.channels } });
+    this.log('[audio] pcm player started (ctx rate ' + this.ctx.sampleRate + ')');
+    for (const b of this._preBuffer) this._post(b);
+    this._preBuffer = [];
+    if (this.ctx.state !== 'running') {
+      this.log('[audio] context suspended — waiting for gesture');
+    }
+  }
+
+  /** Call from a user-gesture handler (iOS autoplay policy). */
+  resume() {
+    if (this.ctx && this.ctx.state !== 'running') {
+      this.ctx.resume().then(() => this.log('[audio] context resumed')).catch(() => {});
+    }
+  }
+
+  close() {
+    this.closed = true;
+    if (this.node) {
+      try { this.node.disconnect(); } catch { /* gone */ }
+      this.node = null;
+    }
+    if (this.ctx) {
+      this.ctx.close().catch(() => {});
+      this.ctx = null;
+    }
+  }
+}

--- a/webbridge/frontend/manifest.webmanifest
+++ b/webbridge/frontend/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "chiaki-web",
+  "short_name": "chiaki-web",
+  "description": "PlayStation Remote Play in the browser",
+  "start_url": "./",
+  "scope": "./",
+  "display": "fullscreen",
+  "display_override": ["fullscreen", "standalone"],
+  "orientation": "landscape",
+  "background_color": "#0a0c10",
+  "theme_color": "#0a0c10",
+  "icons": [
+    {
+      "src": "assets/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/webbridge/src/chiakisource.cpp
+++ b/webbridge/src/chiakisource.cpp
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#include "chiakisource.hpp"
+#include "log.hpp"
+#include "nalparse.hpp"
+
+#include <chiaki/videoreceiver.h>
+
+#include <nlohmann/json.hpp>
+
+#include <cstring>
+
+using nlohmann::json;
+
+ChiakiSource::ChiakiSource(ConsoleConfig console_, StreamProfile profile_, const std::array<uint8_t, 8> &psn_account_id_)
+	: console(std::move(console_)), profile(profile_), psn_account_id(psn_account_id_)
+{
+	chiaki_controller_state_set_idle(&controller_state);
+}
+
+ChiakiSource::~ChiakiSource()
+{
+	stop();
+}
+
+bool ChiakiSource::start(SourceSink sink_, std::string &error)
+{
+	sink = std::move(sink_);
+
+	ChiakiConnectInfo info = {};
+	info.ps5 = console.ps5;
+	info.host = console.host.c_str();
+	static_assert(sizeof(info.regist_key) == 16, "regist key size");
+	memcpy(info.regist_key, console.regist_key.data(), sizeof(info.regist_key));
+	memcpy(info.morning, console.rp_key.data(), sizeof(info.morning));
+	memcpy(info.psn_account_id, psn_account_id.data(), sizeof(info.psn_account_id));
+	info.video_profile.width = profile.width;
+	info.video_profile.height = profile.height;
+	info.video_profile.max_fps = profile.fps;
+	info.video_profile.codec = profile.hevc ? CHIAKI_CODEC_H265 : CHIAKI_CODEC_H264;
+	// bitrate presets follow the GUI's mapping loosely; console clamps anyway
+	unsigned kbps = profile.bitrate;
+	if(!kbps)
+	{
+		if(profile.height >= 1080)
+			kbps = 15000;
+		else if(profile.height >= 720)
+			kbps = 10000;
+		else
+			kbps = 4000;
+	}
+	info.video_profile.bitrate = kbps;
+	info.video_profile_auto_downgrade = true;
+	info.enable_keyboard = false;
+	info.enable_dualsense = true;
+	info.audio_video_disabled = CHIAKI_NONE_DISABLED;
+	info.packet_loss_max = 0.05;
+	info.enable_idr_on_fec_failure = true;
+
+	ChiakiErrorCode err = chiaki_session_init(&session, &info, bridge_log());
+	if(err != CHIAKI_ERR_SUCCESS)
+	{
+		error = std::string("session init failed: ") + chiaki_error_string(err);
+		return false;
+	}
+	session_inited = true;
+
+	chiaki_session_set_video_sample_cb(&session, video_cb, this);
+	audio_sink.user = this;
+	audio_sink.header_cb = audio_header_cb;
+	audio_sink.frame_cb = audio_frame_cb;
+	chiaki_session_set_audio_sink(&session, &audio_sink);
+	chiaki_session_set_event_cb(&session, event_cb, this);
+
+	// Microphone: lib-side Opus encoder + audio sender, fed with PCM from the
+	// browser. Same parameters the Qt GUI uses (2ch/16bit/48kHz, 480-sample
+	// frames — the console requires the resulting exact 40-byte Opus frames).
+	chiaki_opus_encoder_init(&opus_encoder, bridge_log());
+	opus_encoder_inited = true;
+	ChiakiAudioHeader mic_header;
+	chiaki_audio_header_set(&mic_header, 2, 16, 48000, 480);
+	chiaki_opus_encoder_header(&mic_header, &opus_encoder, &session);
+
+	err = chiaki_session_start(&session);
+	if(err != CHIAKI_ERR_SUCCESS)
+	{
+		error = std::string("session start failed: ") + chiaki_error_string(err);
+		chiaki_session_fini(&session);
+		session_inited = false;
+		return false;
+	}
+	started = true;
+	CHIAKI_LOGI(bridge_log(), "webbridge: session started to %s (%s, %ux%u@%u %s)",
+			console.host.c_str(), console.ps5 ? "PS5" : "PS4",
+			profile.width, profile.height, profile.fps, profile.hevc ? "hevc" : "h264");
+	return true;
+}
+
+void ChiakiSource::stop()
+{
+	mic_live = false;
+	if(started.exchange(false))
+	{
+		chiaki_session_stop(&session);
+		chiaki_session_join(&session);
+	}
+	if(opus_encoder_inited)
+	{
+		std::lock_guard<std::mutex> lock(mic_mutex);
+		chiaki_opus_encoder_fini(&opus_encoder);
+		opus_encoder_inited = false;
+	}
+	if(session_inited)
+	{
+		chiaki_session_fini(&session);
+		session_inited = false;
+	}
+}
+
+void ChiakiSource::request_idr()
+{
+	if(!started)
+		return;
+	// Explicitly ask the console for an IDR (the desktop client's path). The
+	// console uses long GOPs during gameplay, so it will NOT emit a keyframe
+	// on its own — only this Takion IDRREQUEST reliably produces one. (The
+	// old approach of just returning false from the video callback merely
+	// reports a corrupt frame and does not force a keyframe here.)
+	ChiakiErrorCode err = chiaki_session_request_idr(&session);
+	if(err == CHIAKI_ERR_SUCCESS)
+	{
+		// Discard deltas until the IDR lands so libchiaki stops logging
+		// "missing reference frame" for every frame in the gap.
+		if(session.stream_connection.video_receiver)
+			chiaki_video_receiver_set_waiting_for_idr(session.stream_connection.video_receiver, true);
+	}
+	else
+		CHIAKI_LOGW(bridge_log(), "webbridge: IDR request failed: %s", chiaki_error_string(err));
+}
+
+bool ChiakiSource::video_cb(uint8_t *buf, size_t buf_size, int32_t frames_lost, bool frame_recovered, void *user)
+{
+	auto *self = static_cast<ChiakiSource *>(user);
+	NalScanResult scan = scan_annexb(buf, buf_size, self->profile.hevc);
+
+	// The console sends SPS/PPS(/VPS) only once, in a separate header AU at
+	// stream start. A browser whose DataChannel opens later (or that drops
+	// that one frame) can never configure its decoder. Cache the parameter
+	// sets and prepend them to every keyframe that lacks them, so any
+	// keyframe is a valid decoder entry point.
+	if(scan.parameter_sets)
+		self->param_sets = extract_param_sets(buf, buf_size, self->profile.hevc);
+	if(self->sink.video_frame)
+	{
+		if(scan.keyframe && !scan.parameter_sets && !self->param_sets.empty())
+		{
+			std::vector<uint8_t> au;
+			au.reserve(self->param_sets.size() + buf_size);
+			au.insert(au.end(), self->param_sets.begin(), self->param_sets.end());
+			au.insert(au.end(), buf, buf + buf_size);
+			self->sink.video_frame(au.data(), au.size(), true);
+		}
+		else
+			self->sink.video_frame(buf, buf_size, scan.keyframe || scan.parameter_sets);
+	}
+	(void)frames_lost;
+	(void)frame_recovered;
+	return true;
+}
+
+void ChiakiSource::audio_header_cb(ChiakiAudioHeader *header, void *user)
+{
+	auto *self = static_cast<ChiakiSource *>(user);
+	CHIAKI_LOGI(bridge_log(), "webbridge: audio header rate=%u ch=%u frame=%u",
+			(unsigned)header->rate, (unsigned)header->channels, (unsigned)header->frame_size);
+	if(self->sink.audio_header)
+		self->sink.audio_header(header->rate, header->channels, header->frame_size);
+}
+
+void ChiakiSource::audio_frame_cb(uint8_t *buf, size_t buf_size, void *user)
+{
+	auto *self = static_cast<ChiakiSource *>(user);
+	if(self->sink.audio_frame)
+		self->sink.audio_frame(buf, buf_size);
+}
+
+void ChiakiSource::event_cb(ChiakiEvent *event, void *user)
+{
+	auto *self = static_cast<ChiakiSource *>(user);
+	auto send = [self](const json &j) {
+		if(self->sink.event)
+			self->sink.event(j.dump());
+	};
+	switch(event->type)
+	{
+		case CHIAKI_EVENT_CONNECTED:
+			CHIAKI_LOGI(bridge_log(), "webbridge: session connected");
+			break;
+		case CHIAKI_EVENT_RUMBLE:
+			send({{"t", "rumble"}, {"l", event->rumble.left}, {"r", event->rumble.right}});
+			break;
+		case CHIAKI_EVENT_LED_COLOR:
+			send({{"t", "led"}, {"r", event->led_state[0]}, {"g", event->led_state[1]}, {"b", event->led_state[2]}});
+			break;
+		case CHIAKI_EVENT_LOGIN_PIN_REQUEST:
+			send({{"t", "pinRequest"}, {"incorrect", event->login_pin_request.pin_incorrect}});
+			break;
+		case CHIAKI_EVENT_NICKNAME_RECEIVED:
+			send({{"t", "nickname"}, {"name", std::string(event->server_nickname, strnlen(event->server_nickname, sizeof(event->server_nickname)))}});
+			break;
+		case CHIAKI_EVENT_QUIT:
+		{
+			const char *reason = chiaki_quit_reason_string(event->quit.reason);
+			bool error = chiaki_quit_reason_is_error(event->quit.reason);
+			CHIAKI_LOGI(bridge_log(), "webbridge: session quit: %s", reason);
+			if(self->sink.quit)
+				self->sink.quit(reason ? reason : "unknown", error);
+			break;
+		}
+		default:
+			break;
+	}
+}
+
+void ChiakiSource::handle_input(const std::string &msg)
+{
+	if(!started)
+		return;
+	json j;
+	try
+	{
+		j = json::parse(msg);
+	}
+	catch(const std::exception &)
+	{
+		return;
+	}
+	const std::string t = j.value("t", "");
+	if(t == "cs")
+	{
+		std::lock_guard<std::mutex> lock(state_mutex);
+		ChiakiControllerState &s = controller_state;
+		uint32_t new_buttons = j.value("b", 0u);
+		if(new_buttons != s.buttons)
+			CHIAKI_LOGI(bridge_log(), "webbridge: buttons 0x%08x -> 0x%08x", s.buttons, new_buttons);
+		s.buttons = new_buttons;
+		s.l2_state = (uint8_t)j.value("l2", 0);
+		s.r2_state = (uint8_t)j.value("r2", 0);
+		s.left_x = (int16_t)j.value("lx", 0);
+		s.left_y = (int16_t)j.value("ly", 0);
+		s.right_x = (int16_t)j.value("rx", 0);
+		s.right_y = (int16_t)j.value("ry", 0);
+		for(auto &touch : s.touches)
+			touch.id = -1;
+		if(j.contains("tp") && j["tp"].is_array())
+		{
+			size_t i = 0;
+			for(const auto &tp : j["tp"])
+			{
+				if(i >= CHIAKI_CONTROLLER_TOUCHES_MAX || !tp.is_array() || tp.size() < 3)
+					break;
+				s.touches[i].id = (int8_t)((int)tp[0] & 0x7f);
+				s.touches[i].x = (uint16_t)std::min<int>(std::max<int>((int)tp[1], 0), 1920);
+				s.touches[i].y = (uint16_t)std::min<int>(std::max<int>((int)tp[2], 0), 942);
+				i++;
+			}
+		}
+		chiaki_session_set_controller_state(&session, &s);
+	}
+	else if(t == "mo")
+	{
+		std::lock_guard<std::mutex> lock(state_mutex);
+		ChiakiControllerState &s = controller_state;
+		s.gyro_x = j.value("gx", 0.0f);
+		s.gyro_y = j.value("gy", 0.0f);
+		s.gyro_z = j.value("gz", 0.0f);
+		s.accel_x = j.value("ax", 0.0f);
+		s.accel_y = j.value("ay", 1.0f);
+		s.accel_z = j.value("az", 0.0f);
+		s.orient_x = j.value("ox", 0.0f);
+		s.orient_y = j.value("oy", 0.0f);
+		s.orient_z = j.value("oz", 0.0f);
+		s.orient_w = j.value("ow", 1.0f);
+		chiaki_session_set_controller_state(&session, &s);
+	}
+	else if(t == "idr")
+	{
+		request_idr();
+	}
+	else if(t == "micOn")
+	{
+		set_mic_enabled(true);
+	}
+	else if(t == "micOff")
+	{
+		set_mic_enabled(false);
+	}
+	else if(t == "pin")
+	{
+		std::string pin = j.value("pin", "");
+		if(!pin.empty())
+			chiaki_session_set_login_pin(&session, (const uint8_t *)pin.data(), pin.size());
+	}
+}
+
+void ChiakiSource::set_mic_enabled(bool enabled)
+{
+	if(!started)
+		return;
+	std::lock_guard<std::mutex> lock(mic_mutex);
+	if(enabled)
+	{
+		if(!mic_connected)
+		{
+			chiaki_session_connect_microphone(&session);
+			mic_connected = true;
+		}
+		if(!mic_live)
+		{
+			// toggle_microphone takes the state being LEFT: true = "was
+			// muted" = unmute now (see ctrl_message_toggle_microphone)
+			chiaki_session_toggle_microphone(&session, true);
+			mic_live = true;
+			CHIAKI_LOGI(bridge_log(), "webbridge: microphone unmuted");
+		}
+	}
+	else if(mic_live)
+	{
+		chiaki_session_toggle_microphone(&session, false);
+		mic_live = false;
+		mic_pending.clear();
+		CHIAKI_LOGI(bridge_log(), "webbridge: microphone muted");
+	}
+}
+
+void ChiakiSource::handle_mic_pcm(const uint8_t *buf, size_t size)
+{
+	if(!started || !mic_live)
+		return;
+	std::lock_guard<std::mutex> lock(mic_mutex);
+	if(!opus_encoder_inited || !opus_encoder.opus_encoder)
+		return;
+
+	// Append incoming mono samples (drop a trailing odd byte, tolerate any
+	// chunking) and emit full 480-sample frames, duplicated to stereo for the
+	// encoder's 2-channel header.
+	const size_t samples = size / 2;
+	const int16_t *pcm = reinterpret_cast<const int16_t *>(buf);
+	mic_pending.insert(mic_pending.end(), pcm, pcm + samples);
+
+	constexpr size_t frame = 480;
+	size_t off = 0;
+	while(mic_pending.size() - off >= frame)
+	{
+		mic_stereo.resize(frame * 2);
+		for(size_t i = 0; i < frame; i++)
+		{
+			mic_stereo[i * 2] = mic_pending[off + i];
+			mic_stereo[i * 2 + 1] = mic_pending[off + i];
+		}
+		chiaki_opus_encoder_frame(mic_stereo.data(), &opus_encoder);
+		off += frame;
+	}
+	mic_pending.erase(mic_pending.begin(), mic_pending.begin() + off);
+	// Bound memory if the browser floods us faster than real time.
+	if(mic_pending.size() > 48000)
+		mic_pending.clear();
+}

--- a/webbridge/src/chiakisource.hpp
+++ b/webbridge/src/chiakisource.hpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#pragma once
+
+#include "config.hpp"
+#include "source.hpp"
+
+#include <chiaki/opusencoder.h>
+#include <chiaki/session.h>
+
+#include <atomic>
+#include <mutex>
+
+// Runs a real Remote Play session against a registered console and adapts
+// libchiaki's callbacks to the SourceSink interface.
+class ChiakiSource : public Source
+{
+public:
+	ChiakiSource(ConsoleConfig console, StreamProfile profile, const std::array<uint8_t, 8> &psn_account_id);
+	~ChiakiSource() override;
+
+	bool start(SourceSink sink, std::string &error) override;
+	void stop() override;
+	void request_idr() override;
+	void handle_input(const std::string &json) override;
+	void handle_mic_pcm(const uint8_t *buf, size_t size) override;
+
+	bool hevc() const { return profile.hevc; }
+
+private:
+	static bool video_cb(uint8_t *buf, size_t buf_size, int32_t frames_lost, bool frame_recovered, void *user);
+	static void audio_header_cb(ChiakiAudioHeader *header, void *user);
+	static void audio_frame_cb(uint8_t *buf, size_t buf_size, void *user);
+	static void event_cb(ChiakiEvent *event, void *user);
+
+	ConsoleConfig console;
+	StreamProfile profile;
+	std::array<uint8_t, 8> psn_account_id;
+
+	ChiakiSession session{};
+	ChiakiAudioSink audio_sink{};
+	bool session_inited = false;
+	std::atomic<bool> started{false};
+	// cached SPS/PPS(/VPS) with start codes; written and read only on the
+	// video callback thread
+	std::vector<uint8_t> param_sets;
+
+	SourceSink sink;
+
+	std::mutex state_mutex;
+	ChiakiControllerState controller_state{};
+
+	void set_mic_enabled(bool enabled);
+
+	// microphone: browser PCM -> lib Opus encoder -> audio sender
+	ChiakiOpusEncoder opus_encoder{};
+	bool opus_encoder_inited = false;
+	std::mutex mic_mutex;
+	bool mic_connected = false;      // connect_microphone sent
+	std::atomic<bool> mic_live{false}; // unmuted & accepting PCM
+	std::vector<int16_t> mic_pending; // mono samples not yet framed
+	std::vector<int16_t> mic_stereo;  // scratch: mono -> interleaved stereo
+};

--- a/webbridge/src/config.cpp
+++ b/webbridge/src/config.cpp
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#include "config.hpp"
+#include "log.hpp"
+
+#include <chiaki/base64.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+
+using nlohmann::json;
+namespace fs = std::filesystem;
+
+static std::string default_config_path()
+{
+	const char *xdg = std::getenv("XDG_CONFIG_HOME");
+	std::string base = xdg && *xdg ? xdg : std::string(std::getenv("HOME") ? std::getenv("HOME") : ".") + "/.config";
+	return base + "/chiaki-web/config.json";
+}
+
+static std::string hex_encode(const uint8_t *buf, size_t size)
+{
+	static const char *d = "0123456789abcdef";
+	std::string s;
+	s.reserve(size * 2);
+	for(size_t i = 0; i < size; i++)
+	{
+		s += d[buf[i] >> 4];
+		s += d[buf[i] & 0xf];
+	}
+	return s;
+}
+
+static bool hex_decode(const std::string &s, uint8_t *buf, size_t size)
+{
+	if(s.size() != size * 2)
+		return false;
+	auto nib = [](char c) -> int {
+		if(c >= '0' && c <= '9') return c - '0';
+		if(c >= 'a' && c <= 'f') return c - 'a' + 10;
+		if(c >= 'A' && c <= 'F') return c - 'A' + 10;
+		return -1;
+	};
+	for(size_t i = 0; i < size; i++)
+	{
+		int hi = nib(s[i * 2]), lo = nib(s[i * 2 + 1]);
+		if(hi < 0 || lo < 0)
+			return false;
+		buf[i] = (uint8_t)((hi << 4) | lo);
+	}
+	return true;
+}
+
+Config::Config(std::string path_override)
+	: path(path_override.empty() ? default_config_path() : std::move(path_override))
+{
+}
+
+void Config::load_psn_account_id_from_env()
+{
+	const char *b64 = std::getenv("CHIAKI_PSN_ACCOUNT_ID");
+	if(!b64 || !*b64)
+		return;
+	size_t sz = psn_account_id.size();
+	if(chiaki_base64_decode(b64, strlen(b64), psn_account_id.data(), &sz) == CHIAKI_ERR_SUCCESS && sz == psn_account_id.size())
+	{
+		psn_account_id_set = true;
+		CHIAKI_LOGI(bridge_log(), "webbridge: PSN account id taken from CHIAKI_PSN_ACCOUNT_ID");
+	}
+	else
+		CHIAKI_LOGE(bridge_log(), "webbridge: CHIAKI_PSN_ACCOUNT_ID is not valid base64 of 8 bytes, ignoring");
+}
+
+void Config::load()
+{
+	std::lock_guard<std::mutex> lock(mutex);
+	consoles.clear();
+	psn_account_id_set = false;
+	std::ifstream f(path);
+	if(!f.good())
+	{
+		load_psn_account_id_from_env();
+		return;
+	}
+	json j;
+	try
+	{
+		f >> j;
+	}
+	catch(const std::exception &e)
+	{
+		CHIAKI_LOGE(bridge_log(), "webbridge: failed to parse config %s: %s", path.c_str(), e.what());
+		return;
+	}
+	if(j.contains("psnAccountId") && j["psnAccountId"].is_string())
+	{
+		std::string b64 = j["psnAccountId"];
+		size_t sz = psn_account_id.size();
+		if(!b64.empty() && chiaki_base64_decode(b64.c_str(), b64.size(), psn_account_id.data(), &sz) == CHIAKI_ERR_SUCCESS && sz == psn_account_id.size())
+			psn_account_id_set = true;
+	}
+	if(!psn_account_id_set)
+		load_psn_account_id_from_env();
+	for(const auto &jc : j.value("consoles", json::array()))
+	{
+		ConsoleConfig c;
+		c.host = jc.value("host", "");
+		c.nickname = jc.value("nickname", "");
+		c.ps5 = jc.value("ps5", true);
+		if(c.host.empty()
+			|| !hex_decode(jc.value("registKey", ""), c.regist_key.data(), c.regist_key.size())
+			|| !hex_decode(jc.value("rpKey", ""), c.rp_key.data(), c.rp_key.size()))
+		{
+			CHIAKI_LOGE(bridge_log(), "webbridge: skipping malformed console entry in config");
+			continue;
+		}
+		consoles.push_back(std::move(c));
+	}
+	CHIAKI_LOGI(bridge_log(), "webbridge: loaded config with %zu console(s) from %s", consoles.size(), path.c_str());
+}
+
+void Config::save()
+{
+	std::lock_guard<std::mutex> lock(mutex);
+	json j;
+	if(psn_account_id_set)
+	{
+		char b64[32] = {};
+		if(chiaki_base64_encode(psn_account_id.data(), psn_account_id.size(), b64, sizeof(b64)) == CHIAKI_ERR_SUCCESS)
+			j["psnAccountId"] = b64;
+	}
+	j["consoles"] = json::array();
+	for(const auto &c : consoles)
+	{
+		j["consoles"].push_back({
+			{"host", c.host},
+			{"nickname", c.nickname},
+			{"ps5", c.ps5},
+			{"registKey", hex_encode(c.regist_key.data(), c.regist_key.size())},
+			{"rpKey", hex_encode(c.rp_key.data(), c.rp_key.size())},
+		});
+	}
+	std::error_code ec;
+	fs::create_directories(fs::path(path).parent_path(), ec);
+	std::ofstream f(path);
+	f << j.dump(1, '\t') << "\n";
+	if(!f.good())
+		CHIAKI_LOGE(bridge_log(), "webbridge: failed to write config %s", path.c_str());
+	else
+		CHIAKI_LOGI(bridge_log(), "webbridge: saved config %s", path.c_str());
+}
+
+const ConsoleConfig *Config::find_console(const std::string &host) const
+{
+	for(const auto &c : consoles)
+		if(c.host == host)
+			return &c;
+	return nullptr;
+}
+
+void Config::upsert_console(const ConsoleConfig &nc)
+{
+	{
+		std::lock_guard<std::mutex> lock(mutex);
+		bool found = false;
+		for(auto &c : consoles)
+		{
+			// Same console re-registered (match by nickname) or same address
+			if(c.host == nc.host || (!nc.nickname.empty() && c.nickname == nc.nickname))
+			{
+				c = nc;
+				found = true;
+				break;
+			}
+		}
+		if(!found)
+			consoles.push_back(nc);
+	}
+	save();
+}
+
+nlohmann::json Config::sanitized() const
+{
+	json j;
+	j["psnAccountIdSet"] = psn_account_id_set;
+	j["consoles"] = json::array();
+	for(const auto &c : consoles)
+		j["consoles"].push_back({{"host", c.host}, {"nickname", c.nickname}, {"ps5", c.ps5}});
+	return j;
+}

--- a/webbridge/src/config.hpp
+++ b/webbridge/src/config.hpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+// A console the bridge is registered (paired) with.
+struct ConsoleConfig
+{
+	std::string host;
+	std::string nickname;
+	bool ps5 = true;
+	// ASCII regist key as chiaki wants it in ChiakiConnectInfo::regist_key
+	// (16 bytes, NUL-padded)
+	std::array<uint8_t, 16> regist_key{};
+	// "morning" / RP key
+	std::array<uint8_t, 16> rp_key{};
+};
+
+class Config
+{
+public:
+	explicit Config(std::string path_override = "");
+
+	void load();
+	void save();
+
+	std::vector<ConsoleConfig> consoles;         // guarded by mutex
+	std::array<uint8_t, 8> psn_account_id{};     // decoded from base64
+	bool psn_account_id_set = false;
+
+	const ConsoleConfig *find_console(const std::string &host) const;
+	void upsert_console(const ConsoleConfig &c);
+
+	nlohmann::json sanitized() const;
+
+	// Fallback: CHIAKI_PSN_ACCOUNT_ID env var (populated from .env by main)
+	void load_psn_account_id_from_env();
+
+	std::mutex mutex;
+
+private:
+	std::string path;
+};

--- a/webbridge/src/demosource.cpp
+++ b/webbridge/src/demosource.cpp
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#include "demosource.hpp"
+#include "log.hpp"
+#include "nalparse.hpp"
+
+#include <opus/opus.h>
+
+#include <poll.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <string>
+#include <vector>
+
+DemoSource::DemoSource(StreamProfile profile_)
+	: profile(profile_)
+{
+}
+
+DemoSource::~DemoSource()
+{
+	stop();
+}
+
+bool DemoSource::start(SourceSink sink_, std::string &error)
+{
+	sink = std::move(sink_);
+
+	char cmd[512];
+	snprintf(cmd, sizeof(cmd),
+			"exec ffmpeg -loglevel error -re -f lavfi "
+			"-i testsrc2=size=%ux%u:rate=%u "
+			"-pix_fmt yuv420p -c:v libx264 -preset veryfast -tune zerolatency "
+			"-profile:v high -g %u -x264-params scenecut=0:repeat-headers=1 "
+			"-bsf:v h264_metadata=aud=insert -f h264 -",
+			profile.width, profile.height, profile.fps, profile.fps * 2);
+	ffmpeg = popen(cmd, "r");
+	if(!ffmpeg)
+	{
+		error = "failed to start ffmpeg for demo mode";
+		return false;
+	}
+	running = true;
+	video_thread = std::thread([this] { video_loop(); });
+	audio_thread = std::thread([this] { audio_loop(); });
+	CHIAKI_LOGI(bridge_log(), "webbridge: demo source started (%ux%u@%u)", profile.width, profile.height, profile.fps);
+	return true;
+}
+
+void DemoSource::stop()
+{
+	if(!running.exchange(false))
+		return;
+	// video_loop polls `running` and exits promptly; only then reap ffmpeg
+	if(video_thread.joinable())
+		video_thread.join();
+	if(audio_thread.joinable())
+		audio_thread.join();
+	if(ffmpeg)
+	{
+		pclose(ffmpeg);
+		ffmpeg = nullptr;
+	}
+}
+
+void DemoSource::request_idr()
+{
+	// x264 emits periodic IDR every g frames; nothing to do.
+}
+
+void DemoSource::handle_input(const std::string &json)
+{
+	// demo mode ignores input, but confirm the channel works once
+	static std::atomic<bool> logged{false};
+	if(!logged.exchange(true))
+		CHIAKI_LOGI(bridge_log(), "webbridge: input DC delivering (first message: %.100s)", json.c_str());
+}
+
+// Scan for an Access Unit Delimiter NAL (type 9) start; AUs run AUD→AUD.
+static size_t find_aud(const std::vector<uint8_t> &buf, size_t from)
+{
+	if(buf.size() < 5)
+		return SIZE_MAX;
+	for(size_t i = from; i + 4 < buf.size(); i++)
+	{
+		if(buf[i] == 0 && buf[i + 1] == 0)
+		{
+			if(buf[i + 2] == 1 && (buf[i + 3] & 0x1f) == 9)
+				return i;
+			if(i + 5 < buf.size() && buf[i + 2] == 0 && buf[i + 3] == 1 && (buf[i + 4] & 0x1f) == 9)
+				return i;
+		}
+	}
+	return SIZE_MAX;
+}
+
+void DemoSource::video_loop()
+{
+	std::vector<uint8_t> buf;
+	buf.reserve(1 << 20);
+	uint8_t chunk[16384];
+	const int fd = fileno(ffmpeg);
+	while(running)
+	{
+		struct pollfd pfd = {fd, POLLIN, 0};
+		int pr = poll(&pfd, 1, 200);
+		if(pr == 0)
+			continue; // timeout: re-check running
+		ssize_t n = pr > 0 ? read(fd, chunk, sizeof(chunk)) : -1;
+		if(n <= 0)
+		{
+			if(running && sink.quit)
+				sink.quit("demo video source ended", true);
+			return;
+		}
+		buf.insert(buf.end(), chunk, chunk + n);
+
+		// emit every complete AU currently in the buffer (AUD → next AUD)
+		for(;;)
+		{
+			size_t first = find_aud(buf, 0);
+			if(first == SIZE_MAX)
+				break;
+			size_t next = find_aud(buf, first + 4);
+			if(next == SIZE_MAX)
+				break;
+			NalScanResult scan = scan_annexb(buf.data() + first, next - first, false);
+			if(sink.video_frame)
+				sink.video_frame(buf.data() + first, next - first, scan.keyframe || scan.parameter_sets);
+			buf.erase(buf.begin(), buf.begin() + next);
+		}
+	}
+}
+
+void DemoSource::audio_loop()
+{
+	constexpr unsigned rate = 48000;
+	constexpr unsigned channels = 2;
+	constexpr unsigned frame_samples = 960; // 20 ms
+
+	if(sink.audio_header)
+		sink.audio_header(rate, channels, frame_samples);
+
+	int err = 0;
+	OpusEncoder *enc = opus_encoder_create(rate, channels, OPUS_APPLICATION_AUDIO, &err);
+	if(!enc || err != OPUS_OK)
+	{
+		CHIAKI_LOGE(bridge_log(), "webbridge: opus encoder init failed (%d)", err);
+		return;
+	}
+	opus_encoder_ctl(enc, OPUS_SET_BITRATE(96000));
+
+	std::vector<int16_t> pcm(frame_samples * channels);
+	std::vector<uint8_t> out(1500);
+	double phase_l = 0, phase_r = 0;
+	auto next_tick = std::chrono::steady_clock::now();
+	uint64_t t = 0;
+	while(running)
+	{
+		// gentle two-tone melody so audio sync/quality is audible
+		double f_l = 329.63 * (1.0 + 0.25 * ((t / 48) % 2));
+		double f_r = 220.0;
+		for(unsigned i = 0; i < frame_samples; i++)
+		{
+			pcm[i * 2] = (int16_t)(std::sin(phase_l) * 6000);
+			pcm[i * 2 + 1] = (int16_t)(std::sin(phase_r) * 6000);
+			phase_l += 2 * M_PI * f_l / rate;
+			phase_r += 2 * M_PI * f_r / rate;
+		}
+		int n = opus_encode(enc, pcm.data(), frame_samples, out.data(), (opus_int32)out.size());
+		if(n > 0 && sink.audio_frame)
+			sink.audio_frame(out.data(), (size_t)n);
+		t++;
+		next_tick += std::chrono::milliseconds(20);
+		std::this_thread::sleep_until(next_tick);
+	}
+	opus_encoder_destroy(enc);
+}

--- a/webbridge/src/demosource.hpp
+++ b/webbridge/src/demosource.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#pragma once
+
+#include "source.hpp"
+
+#include <atomic>
+#include <cstdio>
+#include <thread>
+
+// Test source needing no console: H.264 test pattern from the ffmpeg CLI
+// (Annex-B, AUD-delimited) plus an Opus test tone from libopus. Exercises the
+// whole browser pipeline (fragmentation, WebCodecs decode, RTP Opus audio).
+class DemoSource : public Source
+{
+public:
+	explicit DemoSource(StreamProfile profile);
+	~DemoSource() override;
+
+	bool start(SourceSink sink, std::string &error) override;
+	void stop() override;
+	void request_idr() override;
+	void handle_input(const std::string &json) override;
+
+private:
+	void video_loop();
+	void audio_loop();
+
+	StreamProfile profile;
+	SourceSink sink;
+	std::atomic<bool> running{false};
+	FILE *ffmpeg = nullptr;
+	std::thread video_thread;
+	std::thread audio_thread;
+};

--- a/webbridge/src/discoverymgr.cpp
+++ b/webbridge/src/discoverymgr.cpp
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#include "discoverymgr.hpp"
+#include "log.hpp"
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+
+#include <cstdlib>
+#include <cstring>
+
+DiscoveryManager::DiscoveryManager() = default;
+
+DiscoveryManager::~DiscoveryManager()
+{
+	stop();
+}
+
+void DiscoveryManager::discovery_cb(ChiakiDiscoveryHost *hosts, size_t hosts_count, void *user)
+{
+	auto *self = static_cast<DiscoveryManager *>(user);
+	std::vector<DiscoveredHost> list;
+	list.reserve(hosts_count);
+	for(size_t i = 0; i < hosts_count; i++)
+	{
+		ChiakiDiscoveryHost &h = hosts[i];
+		DiscoveredHost d;
+		d.host_addr = h.host_addr ? h.host_addr : "";
+		d.host_name = h.host_name ? h.host_name : "";
+		d.host_id = h.host_id ? h.host_id : "";
+		d.app_name = h.running_app_name ? h.running_app_name : "";
+		d.ps5 = chiaki_discovery_host_is_ps5(&h);
+		d.ready = h.state == CHIAKI_DISCOVERY_HOST_STATE_READY;
+		d.standby = h.state == CHIAKI_DISCOVERY_HOST_STATE_STANDBY;
+		list.push_back(std::move(d));
+	}
+	std::lock_guard<std::mutex> lock(self->mutex);
+	self->hosts_ = std::move(list);
+}
+
+bool DiscoveryManager::start(const std::vector<std::string> &extra_unicast)
+{
+	if(active)
+		return true;
+
+	static struct sockaddr_in send_addr;
+	memset(&send_addr, 0, sizeof(send_addr));
+	send_addr.sin_family = AF_INET;
+	send_addr.sin_addr.s_addr = INADDR_BROADCAST;
+
+	ChiakiDiscoveryServiceOptions options = {};
+	options.hosts_max = 16;
+	options.host_drop_pings = 3;
+	options.ping_ms = 500;
+	options.ping_initial_ms = 100;
+	options.send_addr = (struct sockaddr_storage *)&send_addr;
+	options.send_addr_size = sizeof(send_addr);
+	options.send_host = nullptr;
+	options.cb = discovery_cb;
+	options.cb_user = this;
+
+	// per-interface directed broadcasts (mirrors the Qt GUI)
+	static std::vector<struct sockaddr_storage> broadcast_addrs;
+	broadcast_addrs.clear();
+	struct ifaddrs *ifs = nullptr;
+	if(getifaddrs(&ifs) == 0)
+	{
+		for(struct ifaddrs *cur = ifs; cur; cur = cur->ifa_next)
+		{
+			if(!cur->ifa_addr || cur->ifa_addr->sa_family != AF_INET)
+				continue;
+			if((cur->ifa_flags & (IFF_UP | IFF_RUNNING | IFF_LOOPBACK | IFF_BROADCAST)) != (IFF_UP | IFF_RUNNING | IFF_BROADCAST))
+				continue;
+			if(!cur->ifa_broadaddr)
+				continue;
+			struct sockaddr_storage ss = {};
+			memcpy(&ss, cur->ifa_broadaddr, sizeof(struct sockaddr_in));
+			broadcast_addrs.push_back(ss);
+		}
+		freeifaddrs(ifs);
+	}
+	for(const auto &host : extra_unicast)
+	{
+		struct sockaddr_in sin = {};
+		sin.sin_family = AF_INET;
+		if(inet_pton(AF_INET, host.c_str(), &sin.sin_addr) == 1)
+		{
+			struct sockaddr_storage ss = {};
+			memcpy(&ss, &sin, sizeof(sin));
+			broadcast_addrs.push_back(ss);
+		}
+	}
+	if(!broadcast_addrs.empty())
+	{
+		options.broadcast_addrs = broadcast_addrs.data();
+		options.broadcast_num = broadcast_addrs.size();
+	}
+
+	ChiakiErrorCode err = chiaki_discovery_service_init(&service, &options, bridge_log());
+	if(err != CHIAKI_ERR_SUCCESS)
+	{
+		CHIAKI_LOGE(bridge_log(), "webbridge: discovery service init failed: %s", chiaki_error_string(err));
+		return false;
+	}
+	active = true;
+	CHIAKI_LOGI(bridge_log(), "webbridge: discovery service running (%zu broadcast addrs)", broadcast_addrs.size());
+	return true;
+}
+
+void DiscoveryManager::stop()
+{
+	if(!active)
+		return;
+	chiaki_discovery_service_fini(&service);
+	active = false;
+}
+
+std::vector<DiscoveredHost> DiscoveryManager::hosts() const
+{
+	std::lock_guard<std::mutex> lock(mutex);
+	return hosts_;
+}
+
+bool DiscoveryManager::send_wakeup(const std::string &host, const std::string &regist_key_hex, bool ps5, std::string &error)
+{
+	uint64_t credential = strtoull(regist_key_hex.c_str(), nullptr, 16);
+	ChiakiErrorCode err = chiaki_discovery_wakeup(bridge_log(), active ? &service.discovery : nullptr,
+			host.c_str(), credential, ps5);
+	if(err != CHIAKI_ERR_SUCCESS)
+	{
+		error = chiaki_error_string(err);
+		return false;
+	}
+	return true;
+}

--- a/webbridge/src/discoverymgr.hpp
+++ b/webbridge/src/discoverymgr.hpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#pragma once
+
+#include <chiaki/discoveryservice.h>
+
+#include <nlohmann/json.hpp>
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+struct DiscoveredHost
+{
+	std::string host_addr;
+	std::string host_name;
+	std::string host_id; // MAC
+	std::string app_name;
+	bool ps5 = false;
+	bool ready = false;
+	bool standby = false;
+};
+
+// Continuous LAN discovery (UDP broadcast ping to PS4/PS5 ports).
+class DiscoveryManager
+{
+public:
+	DiscoveryManager();
+	~DiscoveryManager();
+
+	// extra_unicast: addresses (registered consoles) pinged directly in
+	// addition to the per-interface broadcasts
+	bool start(const std::vector<std::string> &extra_unicast = {});
+	void stop();
+
+	std::vector<DiscoveredHost> hosts() const;
+
+	// One-shot wakeup packet. regist_key is the ASCII-hex credential.
+	bool send_wakeup(const std::string &host, const std::string &regist_key_hex, bool ps5, std::string &error);
+
+private:
+	static void discovery_cb(ChiakiDiscoveryHost *hosts, size_t hosts_count, void *user);
+
+	ChiakiDiscoveryService service{};
+	bool active = false;
+
+	mutable std::mutex mutex;
+	std::vector<DiscoveredHost> hosts_;
+};

--- a/webbridge/src/log.hpp
+++ b/webbridge/src/log.hpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#pragma once
+
+#include <chiaki/log.h>
+
+// Single process-wide chiaki logger printing to stdout.
+inline ChiakiLog *bridge_log()
+{
+	static ChiakiLog log = []() {
+		ChiakiLog l;
+		chiaki_log_init(&l, CHIAKI_LOG_ALL & ~CHIAKI_LOG_VERBOSE & ~CHIAKI_LOG_DEBUG, chiaki_log_cb_print, nullptr);
+		return l;
+	}();
+	return &log;
+}
+
+inline void bridge_log_set_verbose(bool verbose)
+{
+	bridge_log()->level_mask = verbose ? (CHIAKI_LOG_ALL & ~CHIAKI_LOG_VERBOSE) : (CHIAKI_LOG_ALL & ~CHIAKI_LOG_VERBOSE & ~CHIAKI_LOG_DEBUG);
+}

--- a/webbridge/src/main.cpp
+++ b/webbridge/src/main.cpp
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#include "config.hpp"
+#include "log.hpp"
+#include "server.hpp"
+
+void relay_init_logging(bool verbose);
+
+#include <chiaki/common.h>
+
+#include <csignal>
+#include <cstdio>
+#include <cstring>
+
+#include <condition_variable>
+#include <mutex>
+
+static std::mutex quit_mutex;
+static std::condition_variable quit_cv;
+static bool quit = false;
+
+static void sig_handler(int)
+{
+	{
+		std::lock_guard<std::mutex> lock(quit_mutex);
+		quit = true;
+	}
+	quit_cv.notify_all();
+}
+
+// Minimal dotenv: KEY=VALUE lines, '#' comments; does not override existing
+// environment variables.
+static void load_dotenv(const std::string &path)
+{
+	FILE *f = fopen(path.c_str(), "r");
+	if(!f)
+		return;
+	char line[1024];
+	while(fgets(line, sizeof(line), f))
+	{
+		char *s = line;
+		while(*s == ' ' || *s == '\t')
+			s++;
+		if(*s == '#' || *s == '\n' || !*s)
+			continue;
+		char *eq = strchr(s, '=');
+		if(!eq)
+			continue;
+		*eq = '\0';
+		char *v = eq + 1;
+		if(char *nl = strchr(v, '\n'))
+			*nl = '\0';
+		// strip optional quotes
+		size_t vl = strlen(v);
+		if(vl >= 2 && ((v[0] == '"' && v[vl - 1] == '"') || (v[0] == '\'' && v[vl - 1] == '\'')))
+		{
+			v[vl - 1] = '\0';
+			v++;
+		}
+		setenv(s, v, 0);
+	}
+	fclose(f);
+	printf("loaded environment from %s\n", path.c_str());
+}
+
+static void usage(const char *argv0)
+{
+	printf("usage: %s [options]\n"
+			"  --http-port <port>   HTTP port for frontend + REST (default 9080)\n"
+			"  --ws-port <port>     signaling WebSocket port (default 9081)\n"
+			"  --bind <addr>        bind address (default 0.0.0.0)\n"
+			"  --frontend <dir>     static frontend directory (default: ./frontend next to binary)\n"
+			"  --config <file>      config path (default ~/.config/chiaki-web/config.json)\n"
+			"  --env <file>         dotenv file (default: ./.env, then <binary dir>/.env)\n"
+			"  --verbose            debug logging\n",
+			argv0);
+}
+
+int main(int argc, char **argv)
+{
+	ServerOptions options;
+	std::string config_path;
+	std::string env_path;
+	bool verbose = false;
+	for(int i = 1; i < argc; i++)
+	{
+		auto arg = [&](const char *name) -> const char * {
+			if(strcmp(argv[i], name) == 0 && i + 1 < argc)
+				return argv[++i];
+			return nullptr;
+		};
+		if(const char *v = arg("--http-port"))
+			options.http_port = (uint16_t)atoi(v);
+		else if(const char *v = arg("--ws-port"))
+			options.ws_port = (uint16_t)atoi(v);
+		else if(const char *v = arg("--bind"))
+			options.bind_address = v;
+		else if(const char *v = arg("--frontend"))
+			options.frontend_dir = v;
+		else if(const char *v = arg("--config"))
+			config_path = v;
+		else if(const char *v = arg("--env"))
+			env_path = v;
+		else if(strcmp(argv[i], "--verbose") == 0)
+		{
+			bridge_log_set_verbose(true);
+			verbose = true;
+		}
+		else
+		{
+			usage(argv[0]);
+			return strcmp(argv[i], "--help") == 0 ? 0 : 1;
+		}
+	}
+
+	ChiakiErrorCode err = chiaki_lib_init();
+	if(err != CHIAKI_ERR_SUCCESS)
+	{
+		fprintf(stderr, "chiaki lib init failed: %s\n", chiaki_error_string(err));
+		return 1;
+	}
+
+	relay_init_logging(verbose);
+
+	// directory containing the binary (for default frontend dir and .env)
+	std::string bin_dir;
+	{
+		char self[4096];
+		ssize_t n = readlink("/proc/self/exe", self, sizeof(self) - 1);
+		if(n > 0)
+		{
+			self[n] = '\0';
+			if(char *slash = strrchr(self, '/'))
+			{
+				*slash = '\0';
+				bin_dir = self;
+			}
+		}
+	}
+	if(options.frontend_dir == "frontend" && !bin_dir.empty())
+		options.frontend_dir = bin_dir + "/frontend";
+
+	if(!env_path.empty())
+		load_dotenv(env_path);
+	else
+	{
+		load_dotenv(".env");
+		if(!bin_dir.empty())
+			load_dotenv(bin_dir + "/.env");
+	}
+
+	Config config(config_path);
+	config.load();
+
+	BridgeServer server(options, config);
+	if(!server.start())
+		return 1;
+
+	signal(SIGINT, sig_handler);
+	signal(SIGTERM, sig_handler);
+	signal(SIGPIPE, SIG_IGN);
+
+	CHIAKI_LOGI(bridge_log(), "webbridge: ready — open http://localhost:%u/", options.http_port);
+	{
+		std::unique_lock<std::mutex> lock(quit_mutex);
+		quit_cv.wait(lock, [] { return quit; });
+	}
+	CHIAKI_LOGI(bridge_log(), "webbridge: shutting down");
+	server.stop();
+	return 0;
+}

--- a/webbridge/src/nalparse.hpp
+++ b/webbridge/src/nalparse.hpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+// Minimal Annex-B scanning: enough to flag keyframes / parameter sets for the
+// fragment header. Codec-agnostic decode stays in the browser.
+
+struct NalScanResult
+{
+	bool keyframe = false;   // IDR/CRA slice present
+	bool parameter_sets = false; // SPS/PPS(/VPS) present
+};
+
+// Walk NAL units; calls cb(nal_type, nal_start_offset_incl_startcode, nal_off).
+template<typename F>
+inline void foreach_nal(const uint8_t *buf, size_t size, bool hevc, F cb)
+{
+	size_t i = 0;
+	while(i + 3 < size)
+	{
+		if(buf[i] == 0 && buf[i + 1] == 0)
+		{
+			size_t nal_off = 0;
+			if(buf[i + 2] == 1)
+				nal_off = i + 3;
+			else if(i + 4 < size && buf[i + 2] == 0 && buf[i + 3] == 1)
+				nal_off = i + 4;
+			if(nal_off && nal_off < size)
+			{
+				uint8_t type = hevc ? (uint8_t)((buf[nal_off] >> 1) & 0x3f) : (uint8_t)(buf[nal_off] & 0x1f);
+				cb(type, i, nal_off);
+				i = nal_off;
+				continue;
+			}
+		}
+		i++;
+	}
+}
+
+inline bool nal_is_keyframe(uint8_t type, bool hevc)
+{
+	return hevc ? (type >= 16 && type <= 21) /* BLA/IDR/CRA */ : type == 5;
+}
+
+inline bool nal_is_param_set(uint8_t type, bool hevc)
+{
+	return hevc ? (type >= 32 && type <= 34) /* VPS/SPS/PPS */ : (type == 7 || type == 8);
+}
+
+inline NalScanResult scan_annexb(const uint8_t *buf, size_t size, bool hevc)
+{
+	NalScanResult res;
+	foreach_nal(buf, size, hevc, [&](uint8_t type, size_t, size_t) {
+		if(nal_is_keyframe(type, hevc))
+			res.keyframe = true;
+		if(nal_is_param_set(type, hevc))
+			res.parameter_sets = true;
+	});
+	return res;
+}
+
+// Extract all parameter-set NALs (with 4-byte start codes) from an AU, e.g.
+// to cache them and prepend to keyframes for clients that joined mid-stream.
+inline std::vector<uint8_t> extract_param_sets(const uint8_t *buf, size_t size, bool hevc)
+{
+	std::vector<uint8_t> out;
+	// collect [start, end) ranges of param-set NALs; end = next NAL start or AU end
+	size_t pending_start = SIZE_MAX;
+	auto flush = [&](size_t end) {
+		if(pending_start == SIZE_MAX)
+			return;
+		static const uint8_t sc[4] = {0, 0, 0, 1};
+		out.insert(out.end(), sc, sc + 4);
+		// skip the original start code (3 or 4 bytes)
+		size_t s = pending_start;
+		size_t skip = (buf[s + 2] == 1) ? 3 : 4;
+		out.insert(out.end(), buf + s + skip, buf + end);
+		pending_start = SIZE_MAX;
+	};
+	foreach_nal(buf, size, hevc, [&](uint8_t type, size_t start, size_t) {
+		flush(start);
+		if(nal_is_param_set(type, hevc))
+			pending_start = start;
+	});
+	flush(size);
+	return out;
+}

--- a/webbridge/src/registration.cpp
+++ b/webbridge/src/registration.cpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#include "registration.hpp"
+#include "log.hpp"
+
+#include <chiaki/regist.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <mutex>
+
+namespace
+{
+
+struct RegistWait
+{
+	std::mutex mutex;
+	std::condition_variable cv;
+	bool done = false;
+	bool success = false;
+	ChiakiRegisteredHost host{};
+};
+
+void regist_cb(ChiakiRegistEvent *event, void *user)
+{
+	auto *wait = static_cast<RegistWait *>(user);
+	std::lock_guard<std::mutex> lock(wait->mutex);
+	switch(event->type)
+	{
+		case CHIAKI_REGIST_EVENT_TYPE_FINISHED_SUCCESS:
+			wait->success = true;
+			if(event->registered_host)
+				wait->host = *event->registered_host;
+			break;
+		default:
+			wait->success = false;
+			break;
+	}
+	wait->done = true;
+	wait->cv.notify_all();
+}
+
+} // namespace
+
+bool register_console(const std::string &host, bool ps5, uint32_t pin,
+		const std::array<uint8_t, 8> &psn_account_id,
+		ConsoleConfig &out, std::string &error)
+{
+	ChiakiRegistInfo info = {};
+	info.target = ps5 ? CHIAKI_TARGET_PS5_1 : CHIAKI_TARGET_PS4_10;
+	info.host = host.c_str();
+	info.broadcast = false;
+	info.psn_online_id = nullptr;
+	memcpy(info.psn_account_id, psn_account_id.data(), sizeof(info.psn_account_id));
+	info.pin = pin;
+	info.console_pin = 0;
+	info.holepunch_info = nullptr;
+	info.rudp = nullptr;
+
+	RegistWait wait;
+	ChiakiRegist regist;
+	ChiakiErrorCode err = chiaki_regist_start(&regist, bridge_log(), &info, regist_cb, &wait);
+	if(err != CHIAKI_ERR_SUCCESS)
+	{
+		error = std::string("regist start failed: ") + chiaki_error_string(err);
+		return false;
+	}
+
+	bool finished;
+	{
+		std::unique_lock<std::mutex> lock(wait.mutex);
+		finished = wait.cv.wait_for(lock, std::chrono::seconds(45), [&wait] { return wait.done; });
+	}
+	if(!finished)
+		chiaki_regist_stop(&regist);
+	chiaki_regist_fini(&regist);
+
+	if(!finished)
+	{
+		error = "registration timed out";
+		return false;
+	}
+	if(!wait.success)
+	{
+		error = "registration failed (check PIN, PSN Account ID, and that Remote Play pairing is open on the console)";
+		return false;
+	}
+
+	out.host = host;
+	out.ps5 = chiaki_target_is_ps5(wait.host.target);
+	out.nickname = std::string(wait.host.server_nickname,
+			strnlen(wait.host.server_nickname, sizeof(wait.host.server_nickname)));
+	static_assert(sizeof(wait.host.rp_regist_key) == 16, "regist key size");
+	memcpy(out.regist_key.data(), wait.host.rp_regist_key, out.regist_key.size());
+	memcpy(out.rp_key.data(), wait.host.rp_key, out.rp_key.size());
+	return true;
+}

--- a/webbridge/src/registration.hpp
+++ b/webbridge/src/registration.hpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#pragma once
+
+#include "config.hpp"
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+// Blocking console pairing (chiaki_regist). Returns true and fills `out` on
+// success; on failure returns false with a human-readable error.
+bool register_console(const std::string &host, bool ps5, uint32_t pin,
+		const std::array<uint8_t, 8> &psn_account_id,
+		ConsoleConfig &out, std::string &error);

--- a/webbridge/src/relay.cpp
+++ b/webbridge/src/relay.cpp
@@ -1,0 +1,496 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#include "relay.hpp"
+#include "log.hpp"
+
+#include <rtc/global.hpp>
+
+#include <chrono>
+#include <cstring>
+#include <random>
+
+using nlohmann::json;
+
+static uint32_t now_ms32()
+{
+	using namespace std::chrono;
+	return (uint32_t)duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
+// Route libdatachannel/libjuice logs (ICE candidate gathering, TURN
+// allocation, DTLS) into the bridge log. Call once; honors --verbose.
+void relay_init_logging(bool verbose)
+{
+	rtc::InitLogger(verbose ? rtc::LogLevel::Verbose : rtc::LogLevel::Info,
+			[](rtc::LogLevel level, std::string message) {
+				ChiakiLogLevel l = level <= rtc::LogLevel::Error ? CHIAKI_LOG_ERROR
+						: level == rtc::LogLevel::Warning ? CHIAKI_LOG_WARNING
+						: level == rtc::LogLevel::Info ? CHIAKI_LOG_INFO
+						: CHIAKI_LOG_DEBUG;
+				chiaki_log(bridge_log(), l, "rtc: %s", message.c_str());
+			});
+}
+
+Relay::Relay(Callbacks cbs_, std::vector<IceServerEntry> ice_servers_)
+	: cbs(std::move(cbs_)), ice_servers(std::move(ice_servers_))
+{
+	sender_thread = std::thread([this] { sender_loop(); });
+}
+
+Relay::~Relay()
+{
+	close();
+	{
+		std::lock_guard<std::mutex> lock(offer_mutex);
+		offer_timer_stop = true;
+	}
+	offer_cv.notify_all();
+	if(offer_timer_thread.joinable())
+		offer_timer_thread.join();
+	{
+		std::lock_guard<std::mutex> lock(queue_mutex);
+		stopping = true;
+	}
+	queue_cv.notify_all();
+	if(sender_thread.joinable())
+		sender_thread.join();
+}
+
+void Relay::setup()
+{
+	std::lock_guard<std::mutex> lock(pc_mutex);
+
+	rtc::Configuration cfg;
+	size_t turn_count = 0;
+	for(const auto &entry : ice_servers)
+	{
+		for(const auto &url : entry.urls)
+		{
+			// libjuice can do STUN and TURN over UDP only; the browser gets
+			// the full list (incl. turns/tcp) via signaling instead.
+			bool stun = url.rfind("stun:", 0) == 0;
+			bool turn_udp = url.rfind("turn:", 0) == 0 && url.find("transport=udp") != std::string::npos;
+			if(!stun && !turn_udp)
+				continue;
+			try
+			{
+				rtc::IceServer server(url);
+				if(turn_udp)
+				{
+					server.username = entry.username;
+					server.password = entry.credential;
+					turn_count++;
+				}
+				cfg.iceServers.push_back(std::move(server));
+			}
+			catch(const std::exception &e)
+			{
+				CHIAKI_LOGW(bridge_log(), "webbridge: skipping ICE server %s: %s", url.c_str(), e.what());
+			}
+		}
+	}
+	if(cfg.iceServers.empty())
+		cfg.iceServers.emplace_back("stun:stun.l.google.com:19302");
+	if(turn_count)
+		CHIAKI_LOGI(bridge_log(), "webbridge: relay using %zu TURN server(s)", turn_count);
+	// Direct P2P from behind a home router: pin all ICE traffic to one UDP
+	// port (CHIAKI_ICE_PORT) so it can be port-forwarded / firewall-pinholed.
+	// With that single port reachable from the internet, the bridge's srflx
+	// candidate works bidirectionally and no relay is needed.
+	if(const char *ip = std::getenv("CHIAKI_ICE_PORT"); ip && *ip)
+	{
+		// Accept "PORT" or "BEGIN-END". A range (rather than one fixed port)
+		// lets libjuice pick a fresh port per connection, avoiding the ICE
+		// role-conflict / TURN 437 collisions that fixed-port reuse causes on
+		// reconnects. Deliberately NOT enableIceUdpMux: mux demuxes by
+		// connection and drops DTLS it can't map; plain per-connection sockets
+		// handle STUN + DTLS + media cleanly. Forward this whole UDP range.
+		uint16_t begin = 0, end = 0;
+		if(const char *dash = strchr(ip, '-'))
+		{
+			begin = (uint16_t)atoi(ip);
+			end = (uint16_t)atoi(dash + 1);
+		}
+		else
+			begin = end = (uint16_t)atoi(ip);
+		if(begin && end && end >= begin)
+		{
+			cfg.portRangeBegin = begin;
+			cfg.portRangeEnd = end;
+			CHIAKI_LOGI(bridge_log(), "webbridge: pinning ICE to UDP ports %u-%u (forward this range)", begin, end);
+		}
+	}
+	// Cap the MTU so the DTLS handshake (large certificate packets) fragments
+	// into datagrams that survive a low-MTU direct path. STUN checks are tiny
+	// and always cross, so an MTU black hole shows up as "ICE connects, DTLS
+	// stalls" — exactly the direct-path symptom here. The relay path hides it
+	// because Cloudflare re-segments.
+	if(const char *m = std::getenv("CHIAKI_MTU"); m && *m)
+	{
+		int mtu = atoi(m);
+		if(mtu > 0)
+		{
+			cfg.mtu = (size_t)mtu;
+			CHIAKI_LOGI(bridge_log(), "webbridge: MTU capped at %d", mtu);
+		}
+	}
+	// Bind ICE to one local interface (the forwarded IPv4 LAN address). This
+	// drops the IPv6 srflx candidate, which would otherwise half-open for
+	// remote clients (residential IPv6 inbound is firewalled) and could be
+	// nominated over the working, port-forwarded IPv4 path.
+	if(const char *ba = std::getenv("CHIAKI_BIND_ADDR"); ba && *ba)
+	{
+		cfg.bindAddress = ba;
+		CHIAKI_LOGI(bridge_log(), "webbridge: binding ICE to %s", ba);
+	}
+	// Diagnostics/last-resort: CHIAKI_FORCE_RELAY=1 makes the bridge use only
+	// TURN-relayed candidates (mirrors the browser's iceTransportPolicy:relay),
+	// which is the path that survives UDP-hostile networks on both ends.
+	if(const char *fr = std::getenv("CHIAKI_FORCE_RELAY"); fr && *fr && *fr != '0')
+	{
+		cfg.iceTransportPolicy = rtc::TransportPolicy::Relay;
+		CHIAKI_LOGI(bridge_log(), "webbridge: forcing relay-only ICE transport");
+	}
+	pc = std::make_shared<rtc::PeerConnection>(cfg);
+
+	pc->onLocalDescription([this](rtc::Description desc) {
+		// Don't emit the offer here — wait for gathering (see send_offer_now).
+		(void)desc;
+	});
+	pc->onLocalCandidate([this](rtc::Candidate cand) {
+		// Candidates found after the offer was sent trickle normally; those
+		// before are already embedded in the offer's SDP.
+		if(offer_sent.load() && cbs.signal_out)
+			cbs.signal_out(json{{"type", "candidate"}, {"candidate", std::string(cand)}, {"mid", cand.mid()}}.dump());
+	});
+	pc->onGatheringStateChange([this](rtc::PeerConnection::GatheringState state) {
+		if(state == rtc::PeerConnection::GatheringState::Complete)
+			send_offer_now();
+	});
+	pc->onStateChange([this](rtc::PeerConnection::State state) {
+		CHIAKI_LOGI(bridge_log(), "webbridge: pc state %d", (int)state);
+		if(state == rtc::PeerConnection::State::Connected)
+			connected_ = true;
+		else if(state == rtc::PeerConnection::State::Failed || state == rtc::PeerConnection::State::Closed
+				|| state == rtc::PeerConnection::State::Disconnected)
+		{
+			bool was = connected_.exchange(false);
+			(void)was;
+			if(state != rtc::PeerConnection::State::Disconnected && cbs.closed)
+				cbs.closed();
+		}
+	});
+
+	// --- Audio: RTP Opus track. MUST precede createDataChannel (offer is
+	// published there), and the SSRC must be in the description so RTCP finds
+	// its way back to the NACK responder.
+	{
+		rtc::Description::Audio audio("audio", rtc::Description::Direction::SendOnly);
+		audio.addOpusCodec(111, "minptime=10;useinbandfec=1;stereo=1;sprop-stereo=1");
+		std::random_device rd;
+		uint32_t ssrc = rd();
+		audio.addSSRC(ssrc, "chiaki-audio");
+		audio_track = pc->addTrack(audio);
+		audio_rtp_config = std::make_shared<rtc::RtpPacketizationConfig>(ssrc, "chiaki-audio", 111,
+				rtc::OpusRtpPacketizer::DefaultClockRate);
+		auto packetizer = std::make_shared<rtc::OpusRtpPacketizer>(audio_rtp_config);
+		packetizer->addToChain(std::make_shared<rtc::RtcpNackResponder>(64));
+		audio_track->setMediaHandler(packetizer);
+	}
+
+	// --- Video DC: ordered + 3 retransmits (see PROTOCOL.md for rationale).
+	{
+		rtc::DataChannelInit init;
+		init.reliability.unordered = false;
+		init.reliability.maxRetransmits = 3;
+		init.negotiated = true;
+		init.id = 0;
+		video_dc = pc->createDataChannel("video", init);
+		video_dc->onOpen([this]() {
+			CHIAKI_LOGI(bridge_log(), "webbridge: video DC open");
+			std::vector<uint8_t> kf;
+			{
+				std::lock_guard<std::mutex> lock(pending_mutex);
+				kf.swap(pending_keyframe);
+			}
+			if(!kf.empty())
+				send_video(kf.data(), kf.size(), true);
+		});
+	}
+
+	// --- Input DC: reliable + ordered (defaults).
+	{
+		rtc::DataChannelInit init;
+		init.negotiated = true;
+		init.id = 2;
+		input_dc = pc->createDataChannel("input", init);
+		input_dc->onMessage([this](rtc::message_variant msg) {
+			if(std::holds_alternative<std::string>(msg) && cbs.input_json)
+				cbs.input_json(std::get<std::string>(msg));
+		});
+	}
+
+	// --- Mic DC (browser -> bridge): raw 48 kHz mono s16le PCM chunks.
+	// Unordered + lossy: a late voice frame is worthless, and the lib's
+	// encoder tolerates gaps far better than bursts of stale audio.
+	{
+		rtc::DataChannelInit init;
+		init.reliability.unordered = true;
+		init.reliability.maxRetransmits = 0;
+		init.negotiated = true;
+		init.id = 4;
+		mic_dc = pc->createDataChannel("mic", init);
+		mic_dc->onMessage([this](rtc::message_variant msg) {
+			if(std::holds_alternative<rtc::binary>(msg) && cbs.mic_pcm)
+			{
+				const auto &b = std::get<rtc::binary>(msg);
+				cbs.mic_pcm(reinterpret_cast<const uint8_t *>(b.data()), b.size());
+			}
+		});
+	}
+
+	// Safety net: if gathering stalls (e.g. a STUN/TURN server is slow or
+	// unreachable), don't hold the offer forever — send whatever we have and
+	// let the rest trickle. TURN allocation is normally done within ~3 s.
+	offer_timer_thread = std::thread([this]() {
+		std::unique_lock<std::mutex> lock(offer_mutex);
+		offer_cv.wait_for(lock, std::chrono::seconds(6), [this] { return offer_timer_stop; });
+		lock.unlock();
+		if(!offer_sent.load())
+		{
+			CHIAKI_LOGW(bridge_log(), "webbridge: ICE gathering slow, sending offer with partial candidates");
+			send_offer_now();
+		}
+	});
+}
+
+void Relay::send_offer_now()
+{
+	// Emit the local description (offer) with all candidates gathered so far
+	// embedded in the SDP. Idempotent: only the first call wins.
+	if(offer_sent.exchange(true))
+		return;
+	{
+		std::lock_guard<std::mutex> lock(offer_mutex);
+		offer_timer_stop = true;
+	}
+	offer_cv.notify_all();
+
+	std::shared_ptr<rtc::PeerConnection> pc_local;
+	{
+		std::lock_guard<std::mutex> lock(pc_mutex);
+		pc_local = pc;
+	}
+	if(!pc_local)
+		return;
+	auto desc = pc_local->localDescription();
+	if(!desc)
+	{
+		offer_sent.store(false); // allow a later retry
+		return;
+	}
+	if(cbs.signal_out)
+		cbs.signal_out(json{{"type", desc->typeString()}, {"sdp", std::string(*desc)}}.dump());
+	CHIAKI_LOGI(bridge_log(), "webbridge: offer sent (gathering %s)",
+			pc_local->gatheringState() == rtc::PeerConnection::GatheringState::Complete ? "complete" : "partial");
+}
+
+void Relay::handle_signal(const json &msg)
+{
+	std::lock_guard<std::mutex> lock(pc_mutex);
+	if(!pc)
+		return;
+	const std::string type = msg.value("type", "");
+	try
+	{
+		if(type == "answer")
+			pc->setRemoteDescription(rtc::Description(msg.value("sdp", ""), "answer"));
+		else if(type == "candidate")
+			pc->addRemoteCandidate(rtc::Candidate(msg.value("candidate", ""), msg.value("mid", "")));
+	}
+	catch(const std::exception &e)
+	{
+		CHIAKI_LOGE(bridge_log(), "webbridge: signaling error on %s: %s", type.c_str(), e.what());
+	}
+}
+
+void Relay::close()
+{
+	std::lock_guard<std::mutex> lock(pc_mutex);
+	connected_ = false;
+	if(video_dc)
+		video_dc->onOpen(nullptr);
+	if(input_dc)
+		input_dc->onMessage(nullptr);
+	if(mic_dc)
+		mic_dc->onMessage(nullptr);
+	if(pc)
+	{
+		pc->onStateChange(nullptr);
+		pc->onLocalDescription(nullptr);
+		pc->onLocalCandidate(nullptr);
+		pc->close();
+	}
+}
+
+void Relay::set_audio_params(unsigned rate, unsigned channels, unsigned samples_per_frame)
+{
+	// RTP timestamps for Opus always tick at 48 kHz regardless of the coded
+	// rate; chiaki streams 48 kHz anyway.
+	(void)rate;
+	(void)channels;
+	audio_samples_per_frame = samples_per_frame ? samples_per_frame : 480;
+}
+
+void Relay::send_audio(const uint8_t *data, size_t size)
+{
+	std::shared_ptr<rtc::Track> track;
+	{
+		std::lock_guard<std::mutex> lock(pc_mutex);
+		track = audio_track;
+	}
+	if(!track || !track->isOpen())
+		return;
+	try
+	{
+		track->send(reinterpret_cast<const std::byte *>(data), size);
+		audio_rtp_config->timestamp += audio_samples_per_frame;
+	}
+	catch(const std::exception &e)
+	{
+		CHIAKI_LOGE(bridge_log(), "webbridge: audio send failed: %s", e.what());
+	}
+}
+
+void Relay::send_video(const uint8_t *data, size_t size, bool keyframe)
+{
+	std::shared_ptr<rtc::DataChannel> dc;
+	{
+		std::lock_guard<std::mutex> lock(pc_mutex);
+		dc = video_dc;
+	}
+	if(!dc || !dc->isOpen())
+	{
+		if(keyframe)
+		{
+			// Hold the newest keyframe so the stream starts decodable the
+			// moment the channel opens.
+			std::lock_guard<std::mutex> lock(pending_mutex);
+			pending_keyframe.assign(data, data + size);
+		}
+		return;
+	}
+
+	Job job;
+	job.data.assign(data, data + size);
+	job.keyframe = keyframe;
+	job.frame_id = next_frame_id.fetch_add(1);
+	job.backend_ts = now_ms32();
+
+	bool dropped = false;
+	{
+		std::lock_guard<std::mutex> lock(queue_mutex);
+		if(queue.size() >= kMaxQueuedFrames)
+		{
+			// Drop oldest delta frames; keyframes stay.
+			for(auto it = queue.begin(); it != queue.end();)
+			{
+				if(!it->keyframe)
+				{
+					it = queue.erase(it);
+					dropped = true;
+					if(queue.size() < kMaxQueuedFrames)
+						break;
+				}
+				else
+					++it;
+			}
+		}
+		queue.push_back(std::move(job));
+	}
+	queue_cv.notify_one();
+	if(dropped && cbs.need_idr)
+	{
+		CHIAKI_LOGW(bridge_log(), "webbridge: video send queue overrun, dropped deltas and requesting IDR");
+		cbs.need_idr();
+	}
+}
+
+void Relay::sender_loop()
+{
+	for(;;)
+	{
+		Job job;
+		{
+			std::unique_lock<std::mutex> lock(queue_mutex);
+			queue_cv.wait(lock, [this] { return stopping || !queue.empty(); });
+			if(stopping)
+				return;
+			job = std::move(queue.front());
+			queue.pop_front();
+		}
+		send_job(job);
+	}
+}
+
+void Relay::send_job(const Job &job)
+{
+	std::shared_ptr<rtc::DataChannel> dc;
+	{
+		std::lock_guard<std::mutex> lock(pc_mutex);
+		dc = video_dc;
+	}
+	if(!dc || !dc->isOpen())
+		return;
+
+	const size_t total = job.data.size();
+	const size_t chunks = (total + kMaxPayloadSize - 1) / kMaxPayloadSize;
+	for(size_t ci = 0; ci < chunks; ci++)
+	{
+		const size_t off = ci * kMaxPayloadSize;
+		const size_t payload = std::min(kMaxPayloadSize, total - off);
+		std::vector<std::byte> buf(kFragHeaderSize + payload);
+		auto w32 = [&buf](size_t at, uint32_t v) {
+			buf[at] = (std::byte)((v >> 24) & 0xff);
+			buf[at + 1] = (std::byte)((v >> 16) & 0xff);
+			buf[at + 2] = (std::byte)((v >> 8) & 0xff);
+			buf[at + 3] = (std::byte)(v & 0xff);
+		};
+		w32(0, job.frame_id);
+		buf[4] = (std::byte)(((uint16_t)ci >> 8) & 0xff);
+		buf[5] = (std::byte)((uint16_t)ci & 0xff);
+		buf[6] = (std::byte)(((uint16_t)chunks >> 8) & 0xff);
+		buf[7] = (std::byte)((uint16_t)chunks & 0xff);
+		buf[8] = (std::byte)(job.keyframe ? 1 : 0);
+		w32(9, (uint32_t)payload);
+		w32(13, job.backend_ts);
+		memcpy(buf.data() + kFragHeaderSize, job.data.data() + off, payload);
+		try
+		{
+			dc->send(buf.data(), buf.size());
+		}
+		catch(const std::exception &e)
+		{
+			CHIAKI_LOGE(bridge_log(), "webbridge: video send failed: %s", e.what());
+			return;
+		}
+	}
+}
+
+void Relay::send_input_json(const std::string &s)
+{
+	std::shared_ptr<rtc::DataChannel> dc;
+	{
+		std::lock_guard<std::mutex> lock(pc_mutex);
+		dc = input_dc;
+	}
+	if(!dc || !dc->isOpen())
+		return;
+	try
+	{
+		dc->send(s);
+	}
+	catch(const std::exception &)
+	{
+	}
+}

--- a/webbridge/src/relay.hpp
+++ b/webbridge/src/relay.hpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#pragma once
+
+#include "transport.hpp"
+
+#include <nlohmann/json.hpp>
+#include <rtc/rtc.hpp>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+// One WebRTC peer: audio as a native RTP Opus track, video as fragmented
+// Annex-B access units on a partially-reliable DataChannel, input as JSON on
+// a reliable DataChannel. Layout and rationale follow moonlight-web (see
+// webbridge/PROTOCOL.md).
+class Relay : public Transport
+{
+public:
+	// ice_servers: optional STUN/TURN entries (e.g. Cloudflare TURN creds
+	// minted per session); only stun: and turn:...?transport=udp URLs are
+	// used (libjuice has no TURN over TCP/TLS). Empty = default STUN.
+	Relay(Callbacks cbs, std::vector<IceServerEntry> ice_servers = {});
+	~Relay() override;
+
+	// Creates the PeerConnection; the SDP offer is emitted via signal_out.
+	// Track must be added before the first DataChannel (libdatachannel
+	// publishes the offer on createDataChannel).
+	void setup() override;
+	void handle_signal(const nlohmann::json &msg) override; // answer / candidate
+	void close() override;
+
+	bool connected() const { return connected_.load(); }
+
+	void set_audio_params(unsigned rate, unsigned channels, unsigned samples_per_frame) override;
+	void send_video(const uint8_t *data, size_t size, bool keyframe) override;
+	void send_audio(const uint8_t *data, size_t size) override;
+	void send_input_json(const std::string &s) override;
+
+private:
+	static constexpr size_t kFragHeaderSize = 17;
+	static constexpr size_t kMaxPayloadSize = 16000;
+	static constexpr size_t kMaxQueuedFrames = 60;
+
+	struct Job
+	{
+		std::vector<uint8_t> data;
+		bool keyframe;
+		uint32_t frame_id;
+		uint32_t backend_ts;
+	};
+
+	void sender_loop();
+	void send_job(const Job &job);
+
+	Callbacks cbs;
+	std::vector<IceServerEntry> ice_servers;
+
+	std::shared_ptr<rtc::PeerConnection> pc;
+	std::shared_ptr<rtc::Track> audio_track;
+	std::shared_ptr<rtc::RtpPacketizationConfig> audio_rtp_config;
+	std::shared_ptr<rtc::DataChannel> video_dc;
+	std::shared_ptr<rtc::DataChannel> input_dc;
+	std::shared_ptr<rtc::DataChannel> mic_dc;
+
+	std::mutex pc_mutex;
+
+	std::atomic<bool> connected_{false};
+	std::atomic<bool> stopping{false};
+	std::atomic<uint32_t> next_frame_id{0};
+
+	// Offer delivery: hold the offer until ICE gathering completes (capped by
+	// a timer) so it carries all candidates — crucially the TURN relay
+	// candidate, which takes a few seconds to allocate. Trickling it in late
+	// lets a restrictive-NAT browser exhaust its checklist and give up before
+	// the relay pair can form. After the offer is sent, later candidates (if
+	// any) trickle normally.
+	void send_offer_now();
+	std::mutex offer_mutex;
+	std::atomic<bool> offer_sent{false};
+	std::thread offer_timer_thread;
+	std::condition_variable offer_cv;
+	bool offer_timer_stop = false;
+
+	unsigned audio_samples_per_frame = 480;
+
+	// pending keyframe if the video DC wasn't open yet
+	std::mutex pending_mutex;
+	std::vector<uint8_t> pending_keyframe;
+
+	std::mutex queue_mutex;
+	std::condition_variable queue_cv;
+	std::deque<Job> queue;
+	std::thread sender_thread;
+};

--- a/webbridge/src/server.cpp
+++ b/webbridge/src/server.cpp
@@ -1,0 +1,728 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#include "server.hpp"
+#include "chiakisource.hpp"
+#include "demosource.hpp"
+#include "log.hpp"
+#include "registration.hpp"
+#include "relay.hpp"
+#include "wstransport.hpp"
+
+#include <chiaki/base64.h>
+
+#include <httplib.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <ctime>
+
+using nlohmann::json;
+
+static const char *BRIDGE_VERSION = "0.1.0";
+
+// Optional shared-secret gate (CHIAKI_WEB_TOKEN in the environment / .env):
+// defense in depth while the bridge is exposed publicly. Static assets and
+// /api/info stay open; anything that touches the console requires the token.
+static std::string web_token()
+{
+	const char *t = std::getenv("CHIAKI_WEB_TOKEN");
+	return t ? t : "";
+}
+
+static bool request_authorized(const httplib::Request &req)
+{
+	std::string token = web_token();
+	if(token.empty())
+		return true;
+	return req.get_header_value("X-Auth-Token") == token;
+}
+
+static bool reject_unauthorized(const httplib::Request &req, httplib::Response &res)
+{
+	if(request_authorized(req))
+		return false;
+	res.status = 401;
+	res.set_content("{\"error\":\"unauthorized\"}", "application/json");
+	return true;
+}
+
+// Mint short-lived STUN/TURN credentials from Cloudflare's TURN service
+// (CHIAKI_TURN_KEY_ID / CHIAKI_TURN_API_TOKEN in the environment / .env).
+// Returns the ready-to-use RTCPeerConnection iceServers array — cached until
+// shortly before the credentials expire. Empty array when unconfigured or the
+// API is unreachable (WebRTC then runs STUN-only, as before).
+static json fetch_turn_ice_servers()
+{
+	const char *key_id = std::getenv("CHIAKI_TURN_KEY_ID");
+	const char *api_token = std::getenv("CHIAKI_TURN_API_TOKEN");
+	if(!key_id || !*key_id || !api_token || !*api_token)
+		return json::array();
+
+	static std::mutex cache_mutex;
+	static json cached = json::array();
+	static time_t cached_until = 0;
+	std::lock_guard<std::mutex> lock(cache_mutex);
+	time_t now = time(nullptr);
+	if(!cached.empty() && now < cached_until)
+		return cached;
+
+	constexpr int ttl = 4 * 3600;
+	httplib::Client cli("https://rtc.live.cloudflare.com");
+	cli.set_connection_timeout(5, 0);
+	cli.set_read_timeout(5, 0);
+	httplib::Headers headers = {{"Authorization", std::string("Bearer ") + api_token}};
+	auto res = cli.Post(("/v1/turn/keys/" + std::string(key_id) + "/credentials/generate-ice-servers").c_str(),
+			headers, json{{"ttl", ttl}}.dump(), "application/json");
+	if(!res || res->status < 200 || res->status >= 300)
+	{
+		CHIAKI_LOGW(bridge_log(), "webbridge: TURN credential fetch failed (%s)",
+				res ? std::to_string(res->status).c_str() : "unreachable");
+		return cached; // possibly stale-but-valid, else empty
+	}
+	json j = json::parse(res->body, nullptr, false);
+	if(!j.is_object() || !j.contains("iceServers"))
+	{
+		CHIAKI_LOGW(bridge_log(), "webbridge: TURN credential response malformed");
+		return cached;
+	}
+	json servers = j["iceServers"];
+	if(servers.is_object()) // older API shape: single object
+		servers = json::array({servers});
+	cached = servers;
+	cached_until = now + ttl - 300; // refresh well before expiry
+	CHIAKI_LOGI(bridge_log(), "webbridge: minted TURN credentials (ttl %d s)", ttl);
+	return cached;
+}
+
+static std::vector<IceServerEntry> ice_entries_from_json(const json &servers)
+{
+	std::vector<IceServerEntry> out;
+	if(!servers.is_array())
+		return out;
+	for(const auto &s : servers)
+	{
+		if(!s.is_object())
+			continue;
+		IceServerEntry e;
+		if(s.contains("urls"))
+		{
+			if(s["urls"].is_string())
+				e.urls.push_back(s["urls"].get<std::string>());
+			else if(s["urls"].is_array())
+				for(const auto &u : s["urls"])
+					if(u.is_string())
+						e.urls.push_back(u.get<std::string>());
+		}
+		e.username = s.value("username", "");
+		e.credential = s.value("credential", "");
+		if(!e.urls.empty())
+			out.push_back(std::move(e));
+	}
+	return out;
+}
+
+BridgeServer::BridgeServer(ServerOptions options_, Config &config_)
+	: options(std::move(options_)), config(config_)
+{
+}
+
+BridgeServer::~BridgeServer()
+{
+	stop();
+}
+
+void BridgeServer::ws_send_json(const std::shared_ptr<rtc::WebSocket> &ws, const json &j)
+{
+	if(!ws || !ws->isOpen())
+		return;
+	try
+	{
+		ws->send(j.dump());
+	}
+	catch(const std::exception &)
+	{
+	}
+}
+
+bool BridgeServer::start()
+{
+	// best-effort; REST still works without it. Registered consoles get
+	// direct unicast pings in case broadcast doesn't reach them.
+	{
+		std::vector<std::string> unicast;
+		std::lock_guard<std::mutex> lock(config.mutex);
+		for(const auto &c : config.consoles)
+			unicast.push_back(c.host);
+		discovery.start(unicast);
+	}
+
+	// --- signaling WebSocket
+	try
+	{
+		rtc::WebSocketServerConfiguration wscfg;
+		wscfg.port = options.ws_port;
+		wscfg.bindAddress = options.bind_address;
+		ws_server = std::make_unique<rtc::WebSocketServer>(wscfg);
+		ws_server->onClient([this](std::shared_ptr<rtc::WebSocket> ws) { on_ws_client(ws); });
+	}
+	catch(const std::exception &e)
+	{
+		CHIAKI_LOGE(bridge_log(), "webbridge: failed to start signaling server on port %u: %s", options.ws_port, e.what());
+		return false;
+	}
+
+	// --- HTTP: static frontend + REST
+	http = std::make_unique<httplib::Server>();
+	// The app is tiny and iterated on constantly; stale JS on phones (Safari
+	// caches hard) is far more expensive than re-fetching ~100 KB.
+	http->set_post_routing_handler([](const httplib::Request &, httplib::Response &res) {
+		res.set_header("Cache-Control", "no-store");
+	});
+	setup_rest();
+	if(!http->set_mount_point("/", options.frontend_dir))
+	{
+		CHIAKI_LOGE(bridge_log(), "webbridge: frontend dir not found: %s", options.frontend_dir.c_str());
+		return false;
+	}
+	if(!http->bind_to_port(options.bind_address, options.http_port))
+	{
+		CHIAKI_LOGE(bridge_log(), "webbridge: failed to bind HTTP on port %u", options.http_port);
+		return false;
+	}
+	http_thread = std::thread([this] { http->listen_after_bind(); });
+
+	CHIAKI_LOGI(bridge_log(), "webbridge: http on %s:%u, signaling ws on %s:%u, frontend: %s",
+			options.bind_address.c_str(), options.http_port,
+			options.bind_address.c_str(), options.ws_port,
+			options.frontend_dir.c_str());
+	return true;
+}
+
+void BridgeServer::stop()
+{
+	stop_stream(nullptr, "shutting down", false, true);
+	if(http)
+		http->stop();
+	if(http_thread.joinable())
+		http_thread.join();
+	ws_server.reset();
+	discovery.stop();
+}
+
+void BridgeServer::setup_rest()
+{
+	http->Get("/api/info", [this](const httplib::Request &, httplib::Response &res) {
+		res.set_content(json{{"name", "chiaki-web"}, {"version", BRIDGE_VERSION}, {"wsPort", options.ws_port}}.dump(), "application/json");
+	});
+
+	http->Get("/api/hosts", [this](const httplib::Request &req, httplib::Response &res) {
+		if(reject_unauthorized(req, res))
+			return;
+		json out = json::array();
+		auto discovered = discovery.hosts();
+		std::lock_guard<std::mutex> lock(config.mutex);
+		for(const auto &d : discovered)
+		{
+			bool registered = false;
+			for(const auto &c : config.consoles)
+				if(c.host == d.host_addr)
+					registered = true;
+			out.push_back({
+				{"host", d.host_addr},
+				{"nickname", d.host_name},
+				{"mac", d.host_id},
+				{"ps5", d.ps5},
+				{"state", d.ready ? "ready" : (d.standby ? "standby" : "unknown")},
+				{"discovered", true},
+				{"registered", registered},
+				{"appName", d.app_name.empty() ? json(nullptr) : json(d.app_name)},
+			});
+		}
+		for(const auto &c : config.consoles)
+		{
+			bool listed = false;
+			for(const auto &j : out)
+				if(j["host"] == c.host)
+					listed = true;
+			if(listed)
+				continue;
+			out.push_back({
+				{"host", c.host},
+				{"nickname", c.nickname},
+				{"mac", ""},
+				{"ps5", c.ps5},
+				{"state", "unknown"},
+				{"discovered", false},
+				{"registered", true},
+				{"appName", nullptr},
+			});
+		}
+		res.set_content(out.dump(), "application/json");
+	});
+
+	http->Post("/api/wakeup", [this](const httplib::Request &req, httplib::Response &res) {
+		if(reject_unauthorized(req, res))
+			return;
+		json j = json::parse(req.body, nullptr, false);
+		std::string host = j.is_object() ? j.value("host", "") : "";
+		ConsoleConfig console;
+		{
+			std::lock_guard<std::mutex> lock(config.mutex);
+			const ConsoleConfig *c = config.find_console(host);
+			if(!c)
+			{
+				res.status = 404;
+				res.set_content(json{{"error", "console not registered"}}.dump(), "application/json");
+				return;
+			}
+			console = *c;
+		}
+		std::string key((const char *)console.regist_key.data(),
+				strnlen((const char *)console.regist_key.data(), console.regist_key.size()));
+		std::string error;
+		if(!discovery.send_wakeup(host, key, console.ps5, error))
+		{
+			res.status = 500;
+			res.set_content(json{{"error", error}}.dump(), "application/json");
+			return;
+		}
+		res.status = 204;
+	});
+
+	http->Post("/api/register", [this](const httplib::Request &req, httplib::Response &res) {
+		if(reject_unauthorized(req, res))
+			return;
+		json j = json::parse(req.body, nullptr, false);
+		if(!j.is_object() || !j.contains("host") || !j.contains("pin"))
+		{
+			res.status = 400;
+			res.set_content(json{{"error", "host and pin required"}}.dump(), "application/json");
+			return;
+		}
+		std::array<uint8_t, 8> account_id = config.psn_account_id;
+		if(j.contains("psnAccountId") && j["psnAccountId"].is_string() && !j["psnAccountId"].get<std::string>().empty())
+		{
+			std::string b64 = j["psnAccountId"];
+			size_t sz = account_id.size();
+			if(chiaki_base64_decode(b64.c_str(), b64.size(), account_id.data(), &sz) != CHIAKI_ERR_SUCCESS || sz != account_id.size())
+			{
+				res.status = 400;
+				res.set_content(json{{"error", "invalid psnAccountId (expect base64 of 8 bytes)"}}.dump(), "application/json");
+				return;
+			}
+			std::lock_guard<std::mutex> lock(config.mutex);
+			config.psn_account_id = account_id;
+			config.psn_account_id_set = true;
+		}
+		else if(!config.psn_account_id_set)
+		{
+			res.status = 400;
+			res.set_content(json{{"error", "psnAccountId required (none stored yet)"}}.dump(), "application/json");
+			return;
+		}
+
+		uint32_t pin = j["pin"].is_number() ? j["pin"].get<uint32_t>() : (uint32_t)strtoul(j["pin"].get<std::string>().c_str(), nullptr, 10);
+		ConsoleConfig console;
+		std::string error;
+		if(!register_console(j.value("host", ""), j.value("ps5", true), pin, account_id, console, error))
+		{
+			res.status = 500;
+			res.set_content(json{{"error", error}}.dump(), "application/json");
+			return;
+		}
+		config.upsert_console(console);
+		res.set_content(json{{"nickname", console.nickname}}.dump(), "application/json");
+	});
+
+	http->Get("/api/config", [this](const httplib::Request &req, httplib::Response &res) {
+		if(reject_unauthorized(req, res))
+			return;
+		std::lock_guard<std::mutex> lock(config.mutex);
+		res.set_content(config.sanitized().dump(), "application/json");
+	});
+}
+
+void BridgeServer::on_ws_client(std::shared_ptr<rtc::WebSocket> ws)
+{
+	CHIAKI_LOGI(bridge_log(), "webbridge: signaling client connected");
+	{
+		std::lock_guard<std::mutex> lock(clients_mutex);
+		clients.push_back(ws);
+	}
+	auto weak = std::weak_ptr<rtc::WebSocket>(ws);
+	ws->onMessage([this, weak](rtc::message_variant msg) {
+		auto ws = weak.lock();
+		if(!ws)
+			return;
+		if(std::holds_alternative<rtc::binary>(msg))
+		{
+			// ws transport upstream data (mic PCM)
+			const auto &b = std::get<rtc::binary>(msg);
+			handle_ws_binary(ws, reinterpret_cast<const uint8_t *>(b.data()), b.size());
+			return;
+		}
+		try
+		{
+			handle_ws_message(ws, std::get<std::string>(msg));
+		}
+		catch(const std::exception &e)
+		{
+			CHIAKI_LOGE(bridge_log(), "webbridge: signaling handler error: %s", e.what());
+		}
+	});
+	ws->onClosed([this, weak]() {
+		auto ws = weak.lock();
+		{
+			std::lock_guard<std::mutex> lock(clients_mutex);
+			clients.erase(std::remove(clients.begin(), clients.end(), ws), clients.end());
+		}
+		std::shared_ptr<Stream> s;
+		{
+			std::lock_guard<std::mutex> lock(stream_mutex);
+			if(stream && stream->ws == ws)
+			{
+				s = stream;
+				stream.reset();
+			}
+		}
+		if(s)
+		{
+			CHIAKI_LOGI(bridge_log(), "webbridge: streaming client disconnected, stopping session");
+			// this is a libdatachannel callback thread; teardown elsewhere
+			std::thread([s]() {
+				if(s->source)
+					s->source->stop();
+				if(auto t = s->get_transport())
+					t->close();
+			}).detach();
+		}
+	});
+}
+
+void BridgeServer::handle_ws_message(std::shared_ptr<rtc::WebSocket> ws, const std::string &msg)
+{
+	json j = json::parse(msg, nullptr, false);
+	if(!j.is_object())
+		return;
+	const std::string type = j.value("type", "");
+
+	// "t"-keyed messages are browser input riding the signaling socket
+	// (ws transport mode) — distinct namespace from "type"-keyed signaling.
+	if(type.empty() && j.contains("t"))
+	{
+		std::shared_ptr<Stream> s;
+		{
+			std::lock_guard<std::mutex> lock(stream_mutex);
+			s = stream;
+		}
+		if(s && s->ws == ws && s->source)
+			s->source->handle_input(msg);
+		return;
+	}
+
+	if(type == "start")
+	{
+		std::string token = web_token();
+		if(!token.empty() && j.value("token", "") != token)
+		{
+			CHIAKI_LOGW(bridge_log(), "webbridge: rejected unauthorized start");
+			ws_send_json(ws, {{"type", "quit"}, {"reason", "unauthorized"}, {"error", true}});
+			return;
+		}
+		start_stream(ws, j);
+	}
+	else if(type == "answer" || type == "candidate")
+	{
+		std::shared_ptr<Stream> s;
+		{
+			std::lock_guard<std::mutex> lock(stream_mutex);
+			s = stream;
+		}
+		if(s && s->ws == ws)
+			if(auto t = s->get_transport())
+				t->handle_signal(j);
+	}
+	else if(type == "switchTransport")
+	{
+		switch_transport(ws, j);
+	}
+	else if(type == "stop")
+	{
+		stop_stream(ws, "stopped", false, true);
+	}
+	else if(type == "clientlog")
+	{
+		CHIAKI_LOGI(bridge_log(), "webbridge[client]: %s", j.value("msg", "").c_str());
+	}
+}
+
+void BridgeServer::start_stream(std::shared_ptr<rtc::WebSocket> ws, const json &msg)
+{
+	std::lock_guard<std::mutex> lock(stream_mutex);
+	if(stream)
+	{
+		ws_send_json(ws, {{"type", "quit"}, {"reason", "busy"}, {"error", true}});
+		return;
+	}
+
+	StreamProfile profile;
+	const std::string res = msg.value("resolution", "720p");
+	if(res == "360p") { profile.width = 640; profile.height = 360; }
+	else if(res == "540p") { profile.width = 960; profile.height = 540; }
+	else if(res == "1080p") { profile.width = 1920; profile.height = 1080; }
+	else { profile.width = 1280; profile.height = 720; }
+	profile.fps = msg.value("fps", 60) == 30 ? 30 : 60;
+	profile.hevc = msg.value("codec", "h264") == "hevc";
+	profile.bitrate = msg.value("bitrate", 0);
+
+	auto s = std::make_shared<Stream>();
+	s->ws = ws;
+
+	bool demo = msg.value("demo", false);
+	if(demo)
+	{
+		profile.hevc = false; // demo encodes H.264
+		s->source = std::make_shared<DemoSource>(profile);
+	}
+	else
+	{
+		const std::string host = msg.value("host", "");
+		ConsoleConfig console;
+		{
+			std::lock_guard<std::mutex> clock(config.mutex);
+			const ConsoleConfig *c = config.find_console(host);
+			if(!c)
+			{
+				ws_send_json(ws, {{"type", "quit"}, {"reason", "console not registered"}, {"error", true}});
+				return;
+			}
+			console = *c;
+		}
+		s->source = std::make_shared<ChiakiSource>(console, profile, config.psn_account_id);
+	}
+
+	auto weak_ws = std::weak_ptr<rtc::WebSocket>(ws);
+	std::weak_ptr<Stream> weak_stream = s;
+
+	const bool use_webrtc = msg.value("transport", "webrtc") != "ws";
+	if(use_webrtc)
+	{
+		// TURN relay (if configured) as the middle fallback tier: browsers
+		// get the full server list; the Relay filters what libjuice can use.
+		json ice_servers = fetch_turn_ice_servers();
+		if(!ice_servers.empty())
+			ws_send_json(ws, {{"type", "iceServers"}, {"iceServers", ice_servers}});
+		s->transport = std::make_shared<Relay>(make_transport_callbacks(ws, weak_stream, true),
+				ice_entries_from_json(ice_servers));
+	}
+	else
+	{
+		s->transport = std::make_shared<WsTransport>(make_transport_callbacks(ws, weak_stream, false));
+	}
+
+	SourceSink sink;
+	sink.video_frame = [weak_stream](const uint8_t *buf, size_t size, bool key) {
+		if(auto s = weak_stream.lock())
+			if(auto t = s->get_transport())
+				t->send_video(buf, size, key);
+	};
+	sink.audio_header = [weak_stream](unsigned rate, unsigned ch, unsigned spf) {
+		if(auto s = weak_stream.lock())
+		{
+			{
+				std::lock_guard<std::mutex> lock(s->audio_mutex);
+				s->audio_rate = rate;
+				s->audio_channels = ch;
+				s->audio_spf = spf;
+			}
+			if(auto t = s->get_transport())
+				t->set_audio_params(rate, ch, spf);
+		}
+	};
+	sink.audio_frame = [weak_stream](const uint8_t *buf, size_t size) {
+		if(auto s = weak_stream.lock())
+			if(auto t = s->get_transport())
+				t->send_audio(buf, size);
+	};
+	sink.event = [weak_stream](const std::string &json_msg) {
+		if(auto s = weak_stream.lock())
+			if(auto t = s->get_transport())
+				t->send_input_json(json_msg);
+	};
+	sink.quit = [this, weak_ws](const std::string &reason, bool error) {
+		// runs on the chiaki session thread; stop_stream joins that thread,
+		// so it must run elsewhere
+		std::thread([this, weak_ws, reason, error]() {
+			if(auto ws = weak_ws.lock())
+				stop_stream(ws, reason, error, true);
+		}).detach();
+	};
+
+	ws_send_json(ws, {
+		{"type", "streamInfo"},
+		{"codec", profile.hevc ? "hevc" : "h264"},
+		{"width", profile.width},
+		{"height", profile.height},
+		{"fps", profile.fps},
+	});
+
+	std::string error;
+	if(!s->source->start(sink, error))
+	{
+		ws_send_json(ws, {{"type", "quit"}, {"reason", error}, {"error", true}});
+		return;
+	}
+	ws_send_json(ws, {{"type", "status"}, {"state", "connecting"}});
+	s->transport->setup(); // webrtc: emits the offer; ws: announces connected
+	stream = s;
+}
+
+Transport::Callbacks BridgeServer::make_transport_callbacks(const std::shared_ptr<rtc::WebSocket> &ws,
+		const std::weak_ptr<Stream> &weak_stream, bool webrtc)
+{
+	auto weak_ws = std::weak_ptr<rtc::WebSocket>(ws);
+	Transport::Callbacks cbs;
+	cbs.signal_out = [weak_ws](const std::string &out) {
+		if(auto ws = weak_ws.lock())
+		{
+			try
+			{
+				ws->send(out);
+			}
+			catch(const std::exception &)
+			{
+			}
+		}
+	};
+	cbs.binary_out = [weak_ws](const uint8_t *buf, size_t size) -> bool {
+		auto ws = weak_ws.lock();
+		if(!ws || !ws->isOpen())
+			return false;
+		try
+		{
+			ws->send(reinterpret_cast<const std::byte *>(buf), size);
+			return true;
+		}
+		catch(const std::exception &)
+		{
+			return false;
+		}
+	};
+	cbs.buffered_amount = [weak_ws]() -> size_t {
+		if(auto ws = weak_ws.lock())
+			return ws->bufferedAmount();
+		return SIZE_MAX; // socket gone: behave as saturated
+	};
+	cbs.input_json = [weak_stream](const std::string &in) {
+		if(auto s = weak_stream.lock())
+			if(s->source)
+				s->source->handle_input(in);
+	};
+	cbs.mic_pcm = [weak_stream](const uint8_t *buf, size_t size) {
+		if(auto s = weak_stream.lock())
+			if(s->source)
+				s->source->handle_mic_pcm(buf, size);
+	};
+	cbs.need_idr = [weak_stream]() {
+		if(auto s = weak_stream.lock())
+			if(s->source)
+				s->source->request_idr();
+	};
+	if(webrtc)
+	{
+		cbs.closed = [this, weak_ws, weak_stream]() {
+			// The pc failed/closed on its own. Give the browser a grace
+			// window to switch to the ws fallback transport before killing
+			// the (expensive to re-establish) console session. Runs detached:
+			// this is a libdatachannel callback thread.
+			std::thread([this, weak_ws, weak_stream]() {
+				std::shared_ptr<Transport> failed_transport;
+				if(auto s = weak_stream.lock())
+					failed_transport = s->get_transport();
+				else
+					return;
+				std::this_thread::sleep_for(std::chrono::seconds(8));
+				auto s = weak_stream.lock();
+				if(!s || s->get_transport() != failed_transport)
+					return; // transport was swapped: fallback succeeded
+				if(auto ws = weak_ws.lock())
+					stop_stream(ws, "peer connection closed", false, true);
+			}).detach();
+		};
+	}
+	return cbs;
+}
+
+// {"type":"switchTransport","transport":"ws"} — mid-session fallback: the
+// browser gave up on WebRTC (or wants to change transports); swap the media
+// path while the chiaki session keeps running, then request a keyframe so
+// the fresh decoder can sync (the source prepends cached SPS/PPS to it).
+void BridgeServer::switch_transport(std::shared_ptr<rtc::WebSocket> ws, const json &msg)
+{
+	if(msg.value("transport", "") != "ws")
+		return;
+	std::shared_ptr<Stream> s;
+	{
+		std::lock_guard<std::mutex> lock(stream_mutex);
+		s = stream;
+	}
+	if(!s || s->ws != ws)
+		return;
+
+	CHIAKI_LOGI(bridge_log(), "webbridge: switching transport to ws (client request)");
+	std::weak_ptr<Stream> weak_stream = s;
+	auto t = std::make_shared<WsTransport>(make_transport_callbacks(ws, weak_stream, false));
+	{
+		std::lock_guard<std::mutex> lock(s->audio_mutex);
+		if(s->audio_rate)
+			t->set_audio_params(s->audio_rate, s->audio_channels, s->audio_spf);
+	}
+	std::shared_ptr<Transport> old;
+	{
+		std::lock_guard<std::mutex> lock(s->transport_mutex);
+		old = s->transport;
+		s->transport = t;
+	}
+	t->setup();
+	if(old)
+	{
+		// close() can block on pc teardown; this may be a ws callback thread
+		std::thread([old]() { old->close(); }).detach();
+	}
+	if(s->source)
+		s->source->request_idr();
+}
+
+void BridgeServer::handle_ws_binary(std::shared_ptr<rtc::WebSocket> ws, const uint8_t *data, size_t size)
+{
+	std::shared_ptr<Stream> s;
+	{
+		std::lock_guard<std::mutex> lock(stream_mutex);
+		s = stream;
+	}
+	if(s && s->ws == ws)
+		if(auto t = s->get_transport())
+			t->handle_ws_binary(data, size);
+}
+
+void BridgeServer::stop_stream(const std::shared_ptr<rtc::WebSocket> &ws, const std::string &reason, bool error, bool notify)
+{
+	std::shared_ptr<Stream> s;
+	{
+		std::lock_guard<std::mutex> lock(stream_mutex);
+		if(!stream)
+			return;
+		if(ws && stream->ws != ws)
+			return;
+		s = stream;
+		stream.reset();
+	}
+	CHIAKI_LOGI(bridge_log(), "webbridge: stopping stream: %s", reason.c_str());
+	if(s->source)
+		s->source->stop();
+	if(auto t = s->get_transport())
+		t->close();
+	if(notify)
+		ws_send_json(s->ws, {{"type", "quit"}, {"reason", reason}, {"error", error}});
+}

--- a/webbridge/src/server.hpp
+++ b/webbridge/src/server.hpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#pragma once
+
+#include "config.hpp"
+#include "discoverymgr.hpp"
+#include "source.hpp"
+#include "transport.hpp"
+
+#include <rtc/rtc.hpp>
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace httplib
+{
+class Server;
+}
+
+struct ServerOptions
+{
+	uint16_t http_port = 9080;
+	uint16_t ws_port = 9081;
+	std::string bind_address = "0.0.0.0";
+	std::string frontend_dir = "frontend";
+};
+
+class BridgeServer
+{
+public:
+	BridgeServer(ServerOptions options, Config &config);
+	~BridgeServer();
+
+	bool start();
+	void stop();
+
+private:
+	// One active streaming client and its session. The transport can be
+	// swapped mid-session (WebRTC -> WebSocket fallback) without touching
+	// the source; senders go through get_transport().
+	struct Stream
+	{
+		std::shared_ptr<rtc::WebSocket> ws;
+		std::shared_ptr<Source> source;
+
+		std::mutex transport_mutex;
+		std::shared_ptr<Transport> transport;
+
+		// audio params cached so a swapped-in transport can be primed
+		std::mutex audio_mutex;
+		unsigned audio_rate = 0, audio_channels = 0, audio_spf = 0;
+
+		std::shared_ptr<Transport> get_transport()
+		{
+			std::lock_guard<std::mutex> lock(transport_mutex);
+			return transport;
+		}
+	};
+
+	void setup_rest();
+	void on_ws_client(std::shared_ptr<rtc::WebSocket> ws);
+	void handle_ws_message(std::shared_ptr<rtc::WebSocket> ws, const std::string &msg);
+	void handle_ws_binary(std::shared_ptr<rtc::WebSocket> ws, const uint8_t *data, size_t size);
+	void start_stream(std::shared_ptr<rtc::WebSocket> ws, const nlohmann::json &msg);
+	void switch_transport(std::shared_ptr<rtc::WebSocket> ws, const nlohmann::json &msg);
+	void stop_stream(const std::shared_ptr<rtc::WebSocket> &ws, const std::string &reason, bool error, bool notify);
+
+	Transport::Callbacks make_transport_callbacks(const std::shared_ptr<rtc::WebSocket> &ws,
+			const std::weak_ptr<Stream> &weak_stream, bool webrtc);
+
+	static void ws_send_json(const std::shared_ptr<rtc::WebSocket> &ws, const nlohmann::json &j);
+
+	ServerOptions options;
+	Config &config;
+	DiscoveryManager discovery;
+
+	std::unique_ptr<httplib::Server> http;
+	std::thread http_thread;
+	std::unique_ptr<rtc::WebSocketServer> ws_server;
+
+	std::mutex stream_mutex;
+	std::shared_ptr<Stream> stream; // null when idle
+
+	// keep connected signaling clients alive (rtc::WebSocketServer hands out
+	// shared_ptrs but does not retain them)
+	std::mutex clients_mutex;
+	std::vector<std::shared_ptr<rtc::WebSocket>> clients;
+};

--- a/webbridge/src/source.hpp
+++ b/webbridge/src/source.hpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
+// Everything a media source (real chiaki session or demo generator) pushes
+// out to the transport. Callbacks may be invoked from arbitrary source
+// threads; the implementation behind them must be thread-safe.
+struct SourceSink
+{
+	// One complete Annex-B access unit.
+	std::function<void(const uint8_t *buf, size_t size, bool keyframe)> video_frame;
+	// Opus frame, still encoded. samples_per_frame at rate hz (from stream header).
+	std::function<void(unsigned rate, unsigned channels, unsigned samples_per_frame)> audio_header;
+	std::function<void(const uint8_t *buf, size_t size)> audio_frame;
+	// Out-of-band event for the browser, already formatted as input-DC JSON text.
+	std::function<void(const std::string &json)> event;
+	// Session ended. error=false for clean stop.
+	std::function<void(const std::string &reason, bool error)> quit;
+};
+
+class Source
+{
+public:
+	virtual ~Source() = default;
+	// Sink must outlive the source or be safely disconnectable via stop().
+	virtual bool start(SourceSink sink, std::string &error) = 0;
+	virtual void stop() = 0;
+	// Ask the source to produce a recovery keyframe soon.
+	virtual void request_idr() = 0;
+	// Input-DC JSON from the browser ("cs", "mo", "pin", "micOn", ...).
+	virtual void handle_input(const std::string &json) = 0;
+	// Microphone PCM from the browser: 48 kHz mono s16le, any whole number of
+	// samples per call (the source re-frames as needed).
+	virtual void handle_mic_pcm(const uint8_t *buf, size_t size)
+	{
+		(void)buf;
+		(void)size;
+	}
+};
+
+struct StreamProfile
+{
+	unsigned width = 1280;
+	unsigned height = 720;
+	unsigned fps = 60;
+	unsigned bitrate = 0; // kbps, 0 = preset default
+	bool hevc = false;
+};

--- a/webbridge/src/transport.hpp
+++ b/webbridge/src/transport.hpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+// STUN/TURN server entry (as minted by a TURN credential API).
+struct IceServerEntry
+{
+	std::vector<std::string> urls;
+	std::string username;
+	std::string credential;
+};
+
+// A media/input path between the bridge and one browser. Two implementations:
+// Relay (WebRTC: RTP audio + DataChannels) and WsTransport (everything
+// multiplexed over the signaling WebSocket for NAT/UDP-hostile networks).
+// The server can swap the transport mid-session ("switchTransport") without
+// touching the chiaki session, so all senders must tolerate being discarded.
+class Transport
+{
+public:
+	struct Callbacks
+	{
+		std::function<void(const std::string &)> signal_out;       // signaling JSON towards browser
+		std::function<bool(const uint8_t *, size_t)> binary_out;   // binary on the signaling WS (WsTransport)
+		std::function<size_t()> buffered_amount;                   // signaling WS send backlog (WsTransport)
+		std::function<void(const std::string &)> input_json;       // input message from browser
+		std::function<void(const uint8_t *, size_t)> mic_pcm;      // mic PCM from browser
+		std::function<void()> need_idr;                            // we dropped delta frames
+		std::function<void()> closed;                              // transport ended on its own
+	};
+
+	virtual ~Transport() = default;
+
+	virtual void setup() = 0;
+	virtual void handle_signal(const nlohmann::json &msg) { (void)msg; }
+	// Binary message that arrived on the signaling WebSocket.
+	virtual void handle_ws_binary(const uint8_t *data, size_t size)
+	{
+		(void)data;
+		(void)size;
+	}
+	virtual void close() = 0;
+
+	virtual void set_audio_params(unsigned rate, unsigned channels, unsigned samples_per_frame) = 0;
+	virtual void send_video(const uint8_t *data, size_t size, bool keyframe) = 0;
+	virtual void send_audio(const uint8_t *data, size_t size) = 0;
+	virtual void send_input_json(const std::string &s) = 0;
+};

--- a/webbridge/src/wstransport.cpp
+++ b/webbridge/src/wstransport.cpp
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#include "wstransport.hpp"
+#include "log.hpp"
+
+#include <opus/opus.h>
+
+#include <chrono>
+#include <cstring>
+
+using nlohmann::json;
+
+static uint32_t now_ms32()
+{
+	using namespace std::chrono;
+	return (uint32_t)duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
+WsTransport::WsTransport(Callbacks cbs_)
+	: cbs(std::move(cbs_))
+{
+}
+
+WsTransport::~WsTransport()
+{
+	close();
+}
+
+void WsTransport::setup()
+{
+	// The socket is the signaling WS, already open — we are "connected" the
+	// moment the browser knows to expect this transport.
+	if(cbs.signal_out)
+	{
+		{
+			std::lock_guard<std::mutex> lock(audio_mutex);
+			if(opus)
+				cbs.signal_out(json{{"type", "audioInfo"}, {"rate", audio_rate}, {"channels", audio_channels}}.dump());
+		}
+		cbs.signal_out(json{{"type", "status"}, {"state", "connected"}}.dump());
+	}
+	CHIAKI_LOGI(bridge_log(), "webbridge: ws transport active");
+}
+
+void WsTransport::close()
+{
+	closed_ = true;
+	std::lock_guard<std::mutex> lock(audio_mutex);
+	if(opus)
+	{
+		opus_decoder_destroy(opus);
+		opus = nullptr;
+	}
+}
+
+void WsTransport::handle_ws_binary(const uint8_t *data, size_t size)
+{
+	if(closed_ || size < 1)
+		return;
+	if(data[0] == kChanMic && cbs.mic_pcm)
+		cbs.mic_pcm(data + 1, size - 1);
+}
+
+void WsTransport::set_audio_params(unsigned rate, unsigned channels, unsigned samples_per_frame)
+{
+	(void)samples_per_frame;
+	std::lock_guard<std::mutex> lock(audio_mutex);
+	if(opus)
+	{
+		opus_decoder_destroy(opus);
+		opus = nullptr;
+	}
+	audio_rate = rate ? rate : 48000;
+	audio_channels = channels ? channels : 2;
+	int err = 0;
+	opus = opus_decoder_create((opus_int32)audio_rate, (int)audio_channels, &err);
+	if(!opus)
+	{
+		CHIAKI_LOGE(bridge_log(), "webbridge: opus decoder init failed: %s", opus_strerror(err));
+		return;
+	}
+	// 120 ms is the maximum opus frame duration
+	pcm_scratch.resize((audio_rate / 1000) * 120 * audio_channels);
+	if(cbs.signal_out)
+		cbs.signal_out(json{{"type", "audioInfo"}, {"rate", audio_rate}, {"channels", audio_channels}}.dump());
+}
+
+void WsTransport::send_audio(const uint8_t *data, size_t size)
+{
+	if(closed_)
+		return;
+	if(cbs.buffered_amount && cbs.buffered_amount() > kAudioDropThreshold)
+		return; // stale voice is worse than a dropout; the player conceals gaps
+	std::lock_guard<std::mutex> lock(audio_mutex);
+	if(!opus)
+		return;
+	int samples = opus_decode(opus, data, (opus_int32)size, pcm_scratch.data(),
+			(int)(pcm_scratch.size() / audio_channels), 0);
+	if(samples <= 0)
+	{
+		CHIAKI_LOGW(bridge_log(), "webbridge: opus decode failed: %s", opus_strerror(samples));
+		return;
+	}
+	const size_t bytes = (size_t)samples * audio_channels * sizeof(int16_t);
+	audio_msg.resize(1 + bytes);
+	audio_msg[0] = kChanAudio;
+	memcpy(audio_msg.data() + 1, pcm_scratch.data(), bytes);
+	std::lock_guard<std::mutex> slock(send_mutex);
+	if(cbs.binary_out)
+		cbs.binary_out(audio_msg.data(), audio_msg.size());
+}
+
+void WsTransport::send_video(const uint8_t *data, size_t size, bool keyframe)
+{
+	if(closed_)
+		return;
+
+	const size_t buffered = cbs.buffered_amount ? cbs.buffered_amount() : 0;
+	if(buffered > (keyframe ? kHardDropThreshold : kDeltaDropThreshold))
+	{
+		idr_pending = true;
+		return;
+	}
+	// Once the backlog drained after drops, get a keyframe to resynchronize.
+	if(idr_pending.exchange(false) && !keyframe && cbs.need_idr)
+	{
+		uint32_t now = now_ms32();
+		if(now - last_idr_req_ms > 1000)
+		{
+			last_idr_req_ms = now;
+			CHIAKI_LOGW(bridge_log(), "webbridge: ws transport dropped frames on backpressure, requesting IDR");
+			cbs.need_idr();
+		}
+	}
+
+	// Single message per AU: [chan][17-byte fragment header][payload], header
+	// identical to the DataChannel format with totalChunks=1 so the frontend
+	// reuses its reassembly path unchanged.
+	std::vector<uint8_t> buf(1 + kFragHeaderSize + size);
+	buf[0] = kChanVideo;
+	uint8_t *h = buf.data() + 1;
+	auto w32 = [h](size_t at, uint32_t v) {
+		h[at] = (uint8_t)((v >> 24) & 0xff);
+		h[at + 1] = (uint8_t)((v >> 16) & 0xff);
+		h[at + 2] = (uint8_t)((v >> 8) & 0xff);
+		h[at + 3] = (uint8_t)(v & 0xff);
+	};
+	w32(0, next_frame_id.fetch_add(1));
+	h[4] = 0;
+	h[5] = 0; // chunkIndex 0
+	h[6] = 0;
+	h[7] = 1; // totalChunks 1
+	h[8] = keyframe ? 1 : 0;
+	w32(9, (uint32_t)size);
+	w32(13, now_ms32());
+	memcpy(buf.data() + 1 + kFragHeaderSize, data, size);
+
+	std::lock_guard<std::mutex> lock(send_mutex);
+	if(cbs.binary_out && !cbs.binary_out(buf.data(), buf.size()))
+		CHIAKI_LOGW(bridge_log(), "webbridge: ws transport video send failed");
+}
+
+void WsTransport::send_input_json(const std::string &s)
+{
+	if(closed_)
+		return;
+	if(cbs.signal_out)
+		cbs.signal_out(s); // "t"-keyed, distinct from "type"-keyed signaling
+}

--- a/webbridge/src/wstransport.hpp
+++ b/webbridge/src/wstransport.hpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+#pragma once
+
+#include "transport.hpp"
+
+#include <atomic>
+#include <mutex>
+
+struct OpusDecoder;
+
+// Fallback transport for networks where WebRTC cannot connect (UDP-hostile
+// wifi, symmetric NATs with no TURN): everything is multiplexed over the
+// signaling WebSocket, which is plain TCP and already traverses whatever
+// proxy/tunnel delivered the page. Binary messages carry a 1-byte channel
+// prefix (see PROTOCOL.md "WebSocket transport"):
+//
+//   0x01 bridge->browser  video: 17-byte fragment header + Annex-B AU
+//   0x02 bridge->browser  audio: interleaved s16le PCM (decoded on the bridge,
+//                         since there is no RTP track to lean on)
+//   0x03 browser->bridge  mic:   48 kHz mono s16le PCM
+//
+// Input and events stay JSON text on the same socket ("t"-keyed, so they
+// cannot collide with "type"-keyed signaling).
+class WsTransport : public Transport
+{
+public:
+	explicit WsTransport(Callbacks cbs);
+	~WsTransport() override;
+
+	void setup() override; // announces {"type":"status","state":"connected"}
+	void handle_ws_binary(const uint8_t *data, size_t size) override;
+	void close() override;
+
+	void set_audio_params(unsigned rate, unsigned channels, unsigned samples_per_frame) override;
+	void send_video(const uint8_t *data, size_t size, bool keyframe) override;
+	void send_audio(const uint8_t *data, size_t size) override;
+	void send_input_json(const std::string &s) override;
+
+private:
+	static constexpr uint8_t kChanVideo = 0x01;
+	static constexpr uint8_t kChanAudio = 0x02;
+	static constexpr uint8_t kChanMic = 0x03;
+	static constexpr size_t kFragHeaderSize = 17;
+	// TCP backpressure policy: past this backlog delta frames get dropped (an
+	// IDR is requested once the send buffer drains), audio gets dropped at a
+	// tighter bound (stale voice is worse than a gap), and a truly saturated
+	// socket drops even keyframes.
+	static constexpr size_t kDeltaDropThreshold = 1u << 20;  // 1 MiB
+	static constexpr size_t kAudioDropThreshold = 1u << 18;  // 256 KiB
+	static constexpr size_t kHardDropThreshold = 8u << 20;   // 8 MiB
+
+	Callbacks cbs;
+
+	std::atomic<bool> closed_{false};
+	std::atomic<uint32_t> next_frame_id{0};
+	std::atomic<bool> idr_pending{false}; // dropped deltas, IDR not yet requested
+	uint32_t last_idr_req_ms = 0;
+
+	std::mutex send_mutex;
+
+	std::mutex audio_mutex;
+	OpusDecoder *opus = nullptr;
+	unsigned audio_rate = 48000;
+	unsigned audio_channels = 2;
+	std::vector<int16_t> pcm_scratch;
+	std::vector<uint8_t> audio_msg;
+};


### PR DESCRIPTION
chiaki-web is a headless bridge that embeds chiaki-lib to run a real Remote Play session and relays it to any modern browser (desktop or mobile). The browser is a thin client; the console-facing half is all libchiaki.

- Video: Annex-B H.264/HEVC access units over a partially-reliable WebRTC DataChannel, decoded with WebCodecs in a worker.
- Audio: the console's Opus as a native RTP Opus track.
- Input: JSON over a reliable DataChannel (keyboard, Gamepad API with rumble, and a dual-stick multi-touch on-screen controller). Mic via the libchiaki Opus encoder.
- WebSocket transport fallback for UDP-hostile networks.
- Discovery / wakeup / pairing over REST; demo mode for pipeline validation.

Gated behind CHIAKI_ENABLE_WEBBRIDGE (OFF by default); self-contained under webbridge/ and consumes only the public libchiaki API. nlohmann/json and cpp-httplib are fetched via FetchContent, not vendored.

See webbridge/README.md and webbridge/PROTOCOL.md.

Note: It works pretty well!  Solid latency, smoothness, and performance on Windows, Mac, and iOS Chrome browsers, even when forwarded over Cloudflare TURN relay servers.


https://github.com/user-attachments/assets/d4a483bd-5858-4349-bf45-e1ef324cd17c